### PR TITLE
Fixing #97

### DIFF
--- a/src/main/java/mServer/crawler/sender/MediathekArd.java
+++ b/src/main/java/mServer/crawler/sender/MediathekArd.java
@@ -340,7 +340,6 @@ public class MediathekArd extends MediathekReader implements Runnable {
                 if (seite2.indexOf("quality\":3") >= 0) {
                     if (liste.size() <= 0) {
                         // Fehler
-//                        System.out.println("Test");
                     }
                 }
                 for (String s : liste) {
@@ -352,6 +351,7 @@ public class MediathekArd extends MediathekReader implements Runnable {
                 liste.clear();
 
                 seite2.extractList("\"_quality\":2", "\"_stream\":\"", "\"", liste);
+                seite2.extractList("_quality\":\"auto\",\"_server\":\"\",\"_cdn\":\"flashls\",\"_stream\":\"", "\"", liste);
                 seite2.extractList("\"_quality\":2", "\"_stream\":[\"", "\"", liste);
                 for (String s : liste) {
                     if (s.startsWith("http")) {


### PR DESCRIPTION
Die fehlende Sendung  für #97 wurde via. "Film & Serie @ One" in der Mediathek gelistet. Die einzige Qualität die gelistet wurde konnte nicht gefunden werden da bisher m3u8 Datein mit der Qualität "auto" nicht beachtet wurden. Ich habe dem ARD Crawler entsprechend das Pattern für diese Sendungen beigebracht.

Die Filmliste enthält nun, wenn ich das beim Testen richtig gesehen habe, einige Sendungen und Filme mehr.

@xaverW Wurden diese Sendungen bisher absichtlich weg gelassen?


Hier eine mit der Änderung erzeugte ARD-Filmliste: https://p.elaon.de/qm0/