### PR TITLE
Action an Phaser deregistrieren, damit Phaser auch beendet wird

### DIFF
--- a/src/main/java/mServer/crawler/sender/MediathekZdf.java
+++ b/src/main/java/mServer/crawler/sender/MediathekZdf.java
@@ -159,7 +159,7 @@ public class MediathekZdf extends MediathekReader {
                     Log.errorLog(496583211, ex, "add film failed: " + video.getWebsiteUrl());
                 }
             }
-            phaser.arrive();
+            phaser.arriveAndDeregister();
         }
     }
 


### PR DESCRIPTION
ZDF-Crawler beendet sich wieder korrekt