### PR TITLE
Fix für doppelte Einträge in Ergebnisliste

### DIFF
--- a/src/main/java/mServer/crawler/AddToFilmlist.java
+++ b/src/main/java/mServer/crawler/AddToFilmlist.java
@@ -18,6 +18,8 @@ import de.mediathekview.mlib.daten.ListeFilme;
 import de.mediathekview.mlib.tool.Hash;
 import de.mediathekview.mlib.tool.Log;
 import de.mediathekview.mlib.tool.MVHttpClient;
+import java.util.Collections;
+import java.util.List;
 import mServer.tool.MserverDaten;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -104,8 +106,10 @@ public class AddToFilmlist {
 
     private void startThreads() {
         final OkHttpClient client = MVHttpClient.getInstance().getReducedTimeOutClient();
+        
+        List syncList = Collections.synchronizedList(listeEinsortieren);
         for (int i = 0; i < NUMBER_OF_THREADS; ++i) {
-            ImportOldFilmlistThread t = new ImportOldFilmlistThread(listeEinsortieren, client);
+            ImportOldFilmlistThread t = new ImportOldFilmlistThread(syncList, client);
             t.setName("ImportOldFilmlistThread Thread-" + i);
             threadList.add(t);
             t.start();
@@ -197,12 +201,12 @@ public class AddToFilmlist {
 
     private class ImportOldFilmlistThread extends Thread {
 
-        private final ListeFilme listeOld;
+        private final List<DatenFilm> listeOld;
         private final ArrayList<DatenFilm> localAddList = new ArrayList<>((vonListe.size() / NUMBER_OF_THREADS) + 500);
         private int treffer = 0;
         private OkHttpClient client = null;
 
-        public ImportOldFilmlistThread(ListeFilme listeOld, OkHttpClient client) {
+        public ImportOldFilmlistThread(List<DatenFilm> listeOld, OkHttpClient client) {
             this.listeOld = listeOld;
             threadCounter.incrementAndGet();
             this.client = client;
@@ -223,7 +227,7 @@ public class AddToFilmlist {
             localAddList.add(film);
         }
 
-        private synchronized DatenFilm popOld(ListeFilme listeOld) {
+        private synchronized DatenFilm popOld(List<DatenFilm> listeOld) {
             if (!listeOld.isEmpty()) {
                 return listeOld.remove(0);
             } else

--- a/src/test/developTest/java/mServer/crawler/AddToFilmlistTest.java
+++ b/src/test/developTest/java/mServer/crawler/AddToFilmlistTest.java
@@ -120,7 +120,22 @@ public class AddToFilmlistTest {
         target.addOldList();
         
         assertThat(list.size(), equalTo(2));
+    }    
+        
+    // Test with list of 100000 different old entries which are online
+    // to ensure the multithreaded onilne check is correct
+    @Test
+    public void testAddHugeFilmList() {
+        for(int i = 0; i < 100000; i++)  {
+            listToAdd.add(createTestFilm(Const.ZDF, "topic " + i, "title " + i, FILM_NAME_ONLINE));
+        }
+
+        AddToFilmlist target = new AddToFilmlist(list, listToAdd);
+        target.addOldList();
+        
+        assertThat(list.size(), equalTo(100002));
     }
+    
     
     private static DatenFilm createTestFilm(String sender, String topic, String title, String filmUrl) {
         DatenFilm film = new DatenFilm(sender, topic, "url", title, baseUrl + filmUrl, "", "", "", 12, "");


### PR DESCRIPTION
Fix für #142, Details zu der Ursache des Problems sind darin beschrieben.

Bei meinen Tests haben sich keine messbaren Performanceunterschiede gezeigt.