### PR TITLE
Fix: Threads in ExecutorService explizit beenden

### DIFF
--- a/src/main/java/mServer/crawler/sender/arte/MediathekArte_de.java
+++ b/src/main/java/mServer/crawler/sender/arte/MediathekArte_de.java
@@ -201,6 +201,15 @@ public class MediathekArte_de extends MediathekReader
      */
     class CategoryLoader extends Thread {
 
+        private final ExecutorService executor;
+        
+        public CategoryLoader() {
+            // Poolgröße beschränken, da ARTE bei zu vielen Anfragen Errorcode 502/504 liefert
+            // 20 als Poolgröße funktioniert bei Tests ohne Probleme, 
+            // u.U. könnte das nach entsprechenden Tests auch erhöht werden
+             executor = Executors.newFixedThreadPool(20);
+        }
+        
         @Override
         public void run() {
             try {
@@ -212,6 +221,8 @@ public class MediathekArte_de extends MediathekReader
                 }
             } catch (Exception ex) {
                 Log.errorLog(894330854, ex, "");
+            } finally {
+                executor.shutdown();
             }
             meldungThreadUndFertig();
         }
@@ -242,11 +253,6 @@ public class MediathekArte_de extends MediathekReader
         private ListeFilme loadPrograms(ArteCategoryFilmsDTO dto) {
             ListeFilme listeFilme = new ListeFilme();
 
-            // Poolgröße beschränken, da ARTE bei zu vielen Anfragen Errorcode 502/504 liefert
-            // 20 als Poolgröße funktioniert bei Tests ohne Probleme, 
-            // u.U. könnte das nach entsprechenden Tests auch erhöht werden
-            ExecutorService executor = Executors.newFixedThreadPool(20);
-            
             Collection<Future<DatenFilm>> futureFilme = new ArrayList<>();
             dto.getProgramIds().forEach(programId -> {
                 futureFilme.add(executor.submit(new ArteProgramIdToDatenFilmCallable(programId, LANG_CODE, getSendername())));


### PR DESCRIPTION
Fix für #225: ExecutorService nur noch einmal für CategoryLoader erzeugen und am Ende wieder beenden, damit keine Threads mehr übrig bleiben