### PR TITLE
ZDF: Suchzeitraum für Zukunft erweitert

### DIFF
--- a/src/main/java/mServer/crawler/sender/newsearch/ZDFSearchTask.java
+++ b/src/main/java/mServer/crawler/sender/newsearch/ZDFSearchTask.java
@@ -47,7 +47,7 @@ public class ZDFSearchTask extends RecursiveTask<Collection<VideoDTO>>
 
                 do
                 {
-                    baseObject = client.executeSearch(page, days, 1);
+                    baseObject = client.executeSearch(page, days, 2);
 
                     if (baseObject != null)
                     {


### PR DESCRIPTION
Suchzeitraum für Zukunft erweitert auf zwei Monate auf Wunsch aus Forum. Tests haben keine signifikante Erhöhung der Crawlerlaufzeit insgesamt ergeben.