### PR TITLE
ARTE: Testrequests für Analyse

### DIFF
--- a/src/main/java/mServer/crawler/sender/arte/ArteHttpClient.java
+++ b/src/main/java/mServer/crawler/sender/arte/ArteHttpClient.java
@@ -21,7 +21,7 @@ public class ArteHttpClient {
   public static final String AUTH_HEADER = "Authorization";
   public static final String AUTH_TOKEN = "Bearer Nzc1Yjc1ZjJkYjk1NWFhN2I2MWEwMmRlMzAzNjI5NmU3NWU3ODg4ODJjOWMxNTMxYzEzZGRjYjg2ZGE4MmIwOA";
   public static final String USER_AGENT = "User-Agent";
-  public static final String USER_AGENT_VALUE = "Mozilla/5.0";
+  public static final String USER_AGENT_VALUE = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0";
 
   public static <T extends Object> T executeRequest(Logger logger, Gson gson, String aUrl, Class<T> aDtoType) {
     T result = null;
@@ -34,6 +34,7 @@ public class ArteHttpClient {
       TimeUnit.MILLISECONDS.sleep(200);
 
       Request request = createRequest(aUrl);
+      Log.sysLog("ARTE: " + aUrl + ", header: " + request.headers().toString());
 
       boolean stop = false;
 
@@ -77,6 +78,8 @@ public class ArteHttpClient {
     }
 
     return builder.addHeader(USER_AGENT, USER_AGENT_VALUE)
+            .addHeader("Accept", "application/json")
+            .addHeader("Accept-Language", "de")
             .url(aUrl).build();
   }
 }

--- a/src/main/java/mServer/crawler/sender/arte/MediathekArte_de.java
+++ b/src/main/java/mServer/crawler/sender/arte/MediathekArte_de.java
@@ -105,27 +105,26 @@ public class MediathekArte_de extends MediathekReader {
     meldungStart();
     if (Config.getStop()) {
       meldungThreadUndFertig();
-    } else {
-      if (CrawlerTool.loadLongMax()) {
-        Log.sysLog("ARTE: no long run because it is not working...");
-        /*addCategories();
+    }
+    /*if (CrawlerTool.loadLongMax()) {
+        addCategories();
         meldungAddMax(listeThemen.size());
 
         for (int t = 0; t < getMaxThreadLaufen(); ++t) {
           Thread th = new CategoryLoader();
           th.setName(getSendername() + t);
           th.start();
-        }*/
-
-      } else {
-        addTage();
-        meldungAddMax(listeThemen.size());
-        for (int t = 0; t < getMaxThreadLaufen(); ++t) {
-          Thread th = new ThemaLaden();
-          th.setName(getSendername() + t);
-          th.start();
         }
-      }
+
+      } else {*/
+    addTage();
+    meldungAddMax(listeThemen.size());
+    for (int t = 0; t < getMaxThreadLaufen(); ++t) {
+      Thread th = new ThemaLaden();
+      th.setName(getSendername() + t);
+      th.start();
+      //}
+
     }
   }
 


### PR DESCRIPTION
weitere Analysen: Crawler führt für Analyse nur noch Testrequests durch