### PR TITLE
Develop kika - Filesize, Dauer und mehr Filme

### DIFF
--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaFilmUrlInfoDto.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaFilmUrlInfoDto.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 public class KikaFilmUrlInfoDto extends FilmUrlInfoDto {
 
     private final String profileName;
+    private long size = 0;
 
     public KikaFilmUrlInfoDto(String aUrl, String aProfileName) {
         super(aUrl);
@@ -18,6 +19,14 @@ public class KikaFilmUrlInfoDto extends FilmUrlInfoDto {
         this.profileName = profileName;
     }
 
+    public long getSize() {
+      return size;
+    }
+    
+    public void setSize(long size) {
+      this.size = size;
+    }
+    
     public String getProfileName() {
         return profileName;
     }

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaLetterPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaLetterPageTask.java
@@ -15,6 +15,7 @@ import java.util.Queue;
 
 public class KikaLetterPageTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
 
+  // siehe Sonntagsmaerchen
   private static final String TOPIC_URL_SELECTOR = "div.teaserStandard a.linkAll";
   private final String baseUrl;
 

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaLetterPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaLetterPageTask.java
@@ -15,7 +15,7 @@ import java.util.Queue;
 
 public class KikaLetterPageTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
 
-  private static final String TOPIC_URL_SELECTOR = ".teaserBroadcastSeries .linkAll";
+  private static final String TOPIC_URL_SELECTOR = "div.teaserStandard a.linkAll";
   private final String baseUrl;
 
   public KikaLetterPageTask(

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaSendungsfolgeVideoDetailsTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaSendungsfolgeVideoDetailsTask.java
@@ -123,7 +123,7 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
     final Elements fileSizeNode = aVideoElement.getElementsByTag("fileSize");
     
     if (downloadUrlNodes.size() == 0 || profileNameNodes.size() == 0 || profileNameNodes.get(0).text().startsWith("Audio")) {
-      LOG.info("Missnig Video element");
+      LOG.info("Missing Video element");
       return null;
       // audio task do not have a video element
     }
@@ -138,7 +138,7 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
     
     if (fileSizeNode.size() > 0) {
       if (KikaSendungsfolgeVideoDetailsTask.isLong(fileSizeNode.get(0).text())) {
-        info.setSize(Long.parseLong(fileSizeNode.get(0).text())/1024/1024);
+        info.setSize(Long.parseLong(fileSizeNode.get(0).text()));
       }
     }
     

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaSendungsfolgeVideoDetailsTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaSendungsfolgeVideoDetailsTask.java
@@ -57,6 +57,18 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
     jsoupConnection = new JsoupConnection();
   }
 
+  private boolean isLong(final String number) {
+    if (number == null) {
+      return false;
+    }
+    try {
+      Long.parseLong(number);
+      return true;
+    } catch (final NumberFormatException numberFormatException) {
+      return false;
+    }
+  }
+
   private void addFilmUrls(
       final Elements videoElements, final String thema, final String title, final Film newFilm) {
     final Set<KikaFilmUrlInfoDto> urlInfos = parseVideoElements(videoElements);
@@ -102,60 +114,48 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
     return Optional.empty();
   }
 
-  private Set<KikaFilmUrlInfoDto> parseVideoElements(final Elements aVideoElements) {
+  private Set<KikaFilmUrlInfoDto> parseVideoElements(final Elements videoElements) {
     final TreeSet<KikaFilmUrlInfoDto> urlInfos = new TreeSet<>(new KikaFilmUrlInfoComparator());
 
-    for (final Element videoElement : aVideoElements) {
-      final KikaFilmUrlInfoDto urlInfo = parseVideoElement(videoElement);
-      if (urlInfo != null) {
-        urlInfos.add(urlInfo);
-      }
-    }
+    videoElements.stream()
+        .map(this::parseVideoElement)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .forEach(urlInfos::add);
 
     return urlInfos.descendingSet();
   }
 
-  private KikaFilmUrlInfoDto parseVideoElement(final Element aVideoElement) {
+  private Optional<KikaFilmUrlInfoDto> parseVideoElement(final Element aVideoElement) {
     final Elements frameWidthNodes = aVideoElement.getElementsByTag("frameWidth");
     final Elements frameHeightNodes = aVideoElement.getElementsByTag("frameHeight");
     final Elements downloadUrlNodes = aVideoElement.getElementsByTag("progressiveDownloadUrl");
     final Elements profileNameNodes = aVideoElement.getElementsByTag("profileName");
     final Elements fileSizeNode = aVideoElement.getElementsByTag("fileSize");
-    
-    if (downloadUrlNodes.size() == 0 || profileNameNodes.size() == 0 || profileNameNodes.get(0).text().startsWith("Audio")) {
+
+    if (downloadUrlNodes.isEmpty()
+        || profileNameNodes.isEmpty()
+        || profileNameNodes.get(0).text().startsWith("Audio")) {
       LOG.info("Missing Video element");
-      return null;
+      return Optional.empty();
       // audio task do not have a video element
     }
+
     final KikaFilmUrlInfoDto info =
         new KikaFilmUrlInfoDto(downloadUrlNodes.get(0).text(), profileNameNodes.get(0).text());
-    String width = frameWidthNodes.get(0).text();
-    String height = frameHeightNodes.get(0).text();
+    final String width = frameWidthNodes.get(0).text();
+    final String height = frameHeightNodes.get(0).text();
 
     if (!width.isEmpty() && !height.isEmpty()) {
       info.setResolution(Integer.parseInt(width), Integer.parseInt(height));
     }
-    
-    if (fileSizeNode.size() > 0) {
-      if (KikaSendungsfolgeVideoDetailsTask.isLong(fileSizeNode.get(0).text())) {
-        info.setSize(Long.parseLong(fileSizeNode.get(0).text()));
-      }
+
+    if (!fileSizeNode.isEmpty() && isLong(fileSizeNode.get(0).text())) {
+      info.setSize(Long.parseLong(fileSizeNode.get(0).text()));
     }
-    
-    return info;
+
+    return Optional.of(info);
   }
-  
-  public static boolean isLong(String strNum) {
-    if (strNum == null) {
-        return false;
-    }
-    try {
-        long d = Long.parseLong(strNum);
-    } catch (NumberFormatException nfe) {
-        return false;
-    }
-    return true;
-}
 
   private Optional<Resolution> getResolutionFromWidth(final FilmUrlInfoDto aUrlInfo) {
     if (aUrlInfo.getWidth() >= 1280) {
@@ -188,14 +188,12 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
           DateUtils.changeDateTimeForMissingISO8601Support(dateNodes.get(0).text());
       try {
         time = LocalDateTime.parse(timeString, DateTimeFormatter.ISO_DATE_TIME);
-      } catch (DateTimeException ignore) {
+      } catch (final DateTimeException ignore) {
         time = LocalDateTime.parse(timeString, webTimeFormatter);
       }
     } else {
       time = LocalDate.now().atStartOfDay();
-      LOG.debug(
-          String.format(
-              "The film \"%s - %s\" has no date so the actual date will be used.", thema, title));
+      LOG.debug("The film \"{} - {}\" has no date so the actual date will be used.", thema, title);
     }
     return time;
   }
@@ -224,7 +222,8 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
               ELEMENT_HEADLINE);
       final Elements websiteUrlNodes =
           orAlternative(document, ELEMENT_BROADCAST_URL, ELEMENT_HTML_URL);
-      final Elements descriptionNodes = orAlternative(document, ELEMENT_BROADCAST_DESCRIPTION, ELEMENT_TEASERTEXT);
+      final Elements descriptionNodes =
+          orAlternative(document, ELEMENT_BROADCAST_DESCRIPTION, ELEMENT_TEASERTEXT);
       final Elements durationNodes = document.getElementsByTag(ELEMENT_DURATION);
       final Elements durationNodesC8 = document.getElementsByTag(ELEMENT_LENGTH);
       final Elements dateNodes = orAlternative(document, ELEMENT_BROADCAST_DATE, ELEMENT_WEBTIME);
@@ -239,49 +238,33 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
         final String title = titleNodes.get(0).text();
 
         final LocalDateTime time = parseTime(dateNodes, thema, title);
-        Optional<Duration> dauer =
-            HtmlDocumentUtils.parseDuration(durationNodes.get(0).text());
+        Optional<Duration> dauer = HtmlDocumentUtils.parseDuration(durationNodes.get(0).text());
         if (dauer.isEmpty()) {
           dauer = Optional.of(Duration.ofSeconds(Integer.parseInt(durationNodesC8.get(0).text())));
         }
 
-        if (dauer.isPresent()) {
+        final Film newFilm =
+            new Film(UUID.randomUUID(), Sender.KIKA, title, thema, time, dauer.get());
+        newFilm.setWebsite(new URL(websiteUrlNodes.get(0).text()));
 
-          final Film newFilm =
-              new Film(UUID.randomUUID(), Sender.KIKA, title, thema, time, dauer.get());
-          newFilm.setWebsite(new URL(websiteUrlNodes.get(0).text()));
+        addFilmUrls(videoElements, thema, title, newFilm);
+        addGeo(newFilm);
 
-          addFilmUrls(videoElements, thema, title, newFilm);
-          addGeo(newFilm);
-
-          if (newFilm.getUrls().isEmpty()) {
-            LOG.error(
-                String.format(
-                    "Can't find/build valid download URLs for the film \"%s - %s\".",
-                    thema, title));
-            crawler.incrementAndGetErrorCount();
-            crawler.updateProgress();
-          } else {
-
-            if (!descriptionNodes.isEmpty()) {
-              newFilm.setBeschreibung(descriptionNodes.get(0).text());
-            }
-            taskResults.add(newFilm);
-            crawler.incrementAndGetActualCount();
-            crawler.updateProgress();
-          }
-        } else {
-          LOG.error(
-              String.format(
-                  "The duration for the film \"%s - %s\" can't be parsed: \"%s\"",
-                  thema, title, durationNodes.get(0).text()));
+        if (newFilm.getUrls().isEmpty()) {
+          LOG.error("Can't find/build valid download URLs for the film \"{} - {}\".", thema, title);
           crawler.incrementAndGetErrorCount();
+          crawler.updateProgress();
+        } else {
+
+          if (!descriptionNodes.isEmpty()) {
+            newFilm.setBeschreibung(descriptionNodes.get(0).text());
+          }
+          taskResults.add(newFilm);
+          crawler.incrementAndGetActualCount();
           crawler.updateProgress();
         }
       } else {
-        LOG.error(
-            String.format(
-                "The video with the URL \"%s\" has not all needed Elements", urlDTO.getUrl()));
+        LOG.error("The video with the URL \"{}\" has not all needed Elements", urlDTO.getUrl());
         crawler.incrementAndGetErrorCount();
         crawler.updateProgress();
       }
@@ -298,7 +281,7 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
 
   private void addGeo(final Film newFilm) {
     final Optional<FilmUrl> url = newFilm.getDefaultUrl();
-    if (!url.isPresent()) {
+    if (url.isEmpty()) {
       return;
     }
 

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaSendungsfolgeVideoDetailsTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaSendungsfolgeVideoDetailsTask.java
@@ -74,7 +74,7 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
         }
         try {
           if (newFilm.getUrl(filmResolution.get()) == null) {
-            newFilm.addUrl(filmResolution.get(), new FilmUrl(urlInfo.getUrl(), serialVersionUID));
+            newFilm.addUrl(filmResolution.get(), new FilmUrl(urlInfo.getUrl(), urlInfo.getSize()));
           }
         } catch (final MalformedURLException e) {
           LOG.debug(
@@ -120,6 +120,7 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
     final Elements frameHeightNodes = aVideoElement.getElementsByTag("frameHeight");
     final Elements downloadUrlNodes = aVideoElement.getElementsByTag("progressiveDownloadUrl");
     final Elements profileNameNodes = aVideoElement.getElementsByTag("profileName");
+    final Elements fileSizeNode = aVideoElement.getElementsByTag("fileSize");
     
     if (downloadUrlNodes.size() == 0 || profileNameNodes.size() == 0 || profileNameNodes.get(0).text().startsWith("Audio")) {
       LOG.info("Missnig Video element");
@@ -134,8 +135,27 @@ public class KikaSendungsfolgeVideoDetailsTask extends AbstractUrlTask<Film, Cra
     if (!width.isEmpty() && !height.isEmpty()) {
       info.setResolution(Integer.parseInt(width), Integer.parseInt(height));
     }
+    
+    if (fileSizeNode.size() > 0) {
+      if (KikaSendungsfolgeVideoDetailsTask.isLong(fileSizeNode.get(0).text())) {
+        info.setSize(Long.parseLong(fileSizeNode.get(0).text())/1024/1024);
+      }
+    }
+    
     return info;
   }
+  
+  public static boolean isLong(String strNum) {
+    if (strNum == null) {
+        return false;
+    }
+    try {
+        long d = Long.parseLong(strNum);
+    } catch (NumberFormatException nfe) {
+        return false;
+    }
+    return true;
+}
 
   private Optional<Resolution> getResolutionFromWidth(final FilmUrlInfoDto aUrlInfo) {
     if (aUrlInfo.getWidth() >= 1280) {

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicLandingPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicLandingPageTask.java
@@ -14,9 +14,9 @@ import org.jsoup.select.Elements;
 import java.util.Queue;
 
 public class KikaTopicLandingPageTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
-
-  private static final String SELECTOR_TOPIC_OVERVIEW1 =
-      ".sectionArticleWrapperRight span.moreBtn > a";
+  // Landingpage with "Folgenübersicht"
+  private static final String SELECTOR_TOPIC_OVERVIEW1 = "span.moreBtn > a";
+  // Landingpage with "Alle Folgen"
   private static final String SELECTOR_TOPIC_OVERVIEW2 = "div.teaserMultiGroup > a.linkAll";
 
   private final String baseUrl;

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicLandingPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicLandingPageTask.java
@@ -14,7 +14,7 @@ import org.jsoup.select.Elements;
 import java.util.Queue;
 
 public class KikaTopicLandingPageTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
-  // Landingpage with "Folgenübersicht"
+  // Button "Folgenübersicht" auch ohne "sectionArticleWrapperRight" (siehe tib und tum-tum)
   private static final String SELECTOR_TOPIC_OVERVIEW1 = "span.moreBtn > a";
   // Landingpage with "Alle Folgen"
   private static final String SELECTOR_TOPIC_OVERVIEW2 = "div.teaserMultiGroup > a.linkAll";
@@ -42,7 +42,9 @@ public class KikaTopicLandingPageTask extends AbstractDocumentTask<CrawlerUrlDTO
   private void parseOverviewLink(final Elements overviewUrlElements) {
     for (final Element overviewUrlElement : overviewUrlElements) {
       final String url = overviewUrlElement.attr(HtmlConsts.ATTRIBUTE_HREF);
-      taskResults.add(new CrawlerUrlDTO(UrlUtils.addDomainIfMissing(url, baseUrl)));
+      if (url.startsWith("http") || url.charAt(0) == '/') {
+        taskResults.add(new CrawlerUrlDTO(UrlUtils.addDomainIfMissing(url, baseUrl)));
+      }
     }
   }
 

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicLandingPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicLandingPageTask.java
@@ -32,11 +32,16 @@ public class KikaTopicLandingPageTask extends AbstractDocumentTask<CrawlerUrlDTO
 
   @Override
   protected void processDocument(final CrawlerUrlDTO aUrlDTO, final Document aDocument) {
-    Elements overviewUrlElements = aDocument.select(SELECTOR_TOPIC_OVERVIEW1);
-    parseOverviewLink(overviewUrlElements);
+    Elements overviewUrlElementsMoteBtn = aDocument.select(SELECTOR_TOPIC_OVERVIEW1);
+    parseOverviewLink(overviewUrlElementsMoteBtn);
 
-    overviewUrlElements = aDocument.select(SELECTOR_TOPIC_OVERVIEW2);
-    parseOverviewLink(overviewUrlElements);
+    Elements overviewUrlElementsMultigroup = aDocument.select(SELECTOR_TOPIC_OVERVIEW2);
+    parseOverviewLink(overviewUrlElementsMultigroup);
+    
+    // es ist eine Uebersichtseite (z.B.Schnitzeljadgt / Schloss Einstein) ohne "Alle Folgen" knopf
+    if (overviewUrlElementsMoteBtn.size() == 0 && overviewUrlElementsMultigroup.size() == 0) {
+      taskResults.add(aUrlDTO);
+    }
   }
 
   private void parseOverviewLink(final Elements overviewUrlElements) {

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicOverviewPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicOverviewPageTask.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class KikaTopicOverviewPageTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
 
-  private static final String SELECTOR_TOPIC_OVERVIEW = "div.boxBroadcast a.linkAll";
+  private static final String SELECTOR_TOPIC_OVERVIEW = "a.linkAll";
   private static final String SELECTOR_SUBPAGES =
       ".modBundleGroupNavi:eq(1) div.bundleNaviItem > a.pageItem";
   private static final String SELECTOR_TYPE_ICON = "span.icon-font";
@@ -119,7 +119,7 @@ public class KikaTopicOverviewPageTask extends AbstractDocumentTask<CrawlerUrlDT
     for (final Element urlElement : urlElements) {
       final String url = urlElement.attr(HtmlConsts.ATTRIBUTE_HREF);
       final Element iconElement = urlElement.parent().select(SELECTOR_TYPE_ICON).first();
-      if (iconElement.text().equals(ENTRY_ICON_FILM)) {
+      if (iconElement != null && iconElement.text().equals(ENTRY_ICON_FILM)) {
         taskResults.add(new CrawlerUrlDTO(UrlUtils.addDomainIfMissing(url, baseUrl)));
       }
     }

--- a/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicOverviewPageTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/kika/tasks/KikaTopicOverviewPageTask.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class KikaTopicOverviewPageTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
 
+  // siehe PUR+, es gibt nicht immer einen boxBroadcast
   private static final String SELECTOR_TOPIC_OVERVIEW = "a.linkAll";
   private static final String SELECTOR_SUBPAGES =
       ".modBundleGroupNavi:eq(1) div.bundleNaviItem > a.pageItem";


### PR DESCRIPTION
Filesize aus den Filmdaten überenehmen
Die Dauer ist in einigen Fällen in DURATION leer aber das LENGTH Element ist gesetzt
Die Selectoren sind zum zu eng gefasst und verpassen zu viele Sendungen.
Auf einigen (wenigen) Seiten gibt es keinen "alle Folgen" link aber Videos. Diese werden jetzt durchgereicht und verarbeitet.
Wenn man mehr Daten crawlt muss man aber auch an der ein oder anderen Stelle mehr abfangen (z.B. href mit java script).
Insgesamt hat der crawler in dev nur 2k Sendungen gefunden. Mit diesen Änderungen sind wir wieder bei ~5k (wie der alten crawler).
