### PR TITLE
nextPageId is missing even if there are subpages

### DIFF
--- a/src/main/java/de/mediathekview/mserver/crawler/arte/ArteConstants.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/arte/ArteConstants.java
@@ -7,10 +7,11 @@ public class ArteConstants {
   public static final String DAY_PAGE_URL =
       BASE_URL_WWW + "/guide/api/emac/v3/%s/web/pages/TV_GUIDE/?day=%s";
 
+  public static final int SUBCATEGORY_LIMIT = 100;
   public static final String URL_SUBCATEGORIES =
-      "https://api.arte.tv/api/opa/v3/subcategories?language=%s&limit=100";
+      "https://api.arte.tv/api/opa/v3/subcategories?language=%s&limit="+SUBCATEGORY_LIMIT;
   public static final String URL_SUBCATEGORY_VIDEOS =
-      "%s/guide/api/emac/v3/%s/web/zones/videos_subcategory/?id=%s&limit=100&page=%s";
+      "%s/guide/api/emac/v3/%s/web/zones/videos_subcategory/?id=%s&limit="+SUBCATEGORY_LIMIT+"&page=%s";
 
   public static final String URL_FILM_DETAILS = "https://api.arte.tv/api/opa/v3/programs/%s/%s";
   public static final String URL_FILM_VIDEOS =

--- a/src/main/java/de/mediathekview/mserver/crawler/arte/tasks/ArteSubcategoryVideosTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/arte/tasks/ArteSubcategoryVideosTask.java
@@ -1,6 +1,9 @@
 package de.mediathekview.mserver.crawler.arte.tasks;
 
 import com.google.gson.reflect.TypeToken;
+
+import de.mediathekview.mserver.base.utils.UrlParseException;
+import de.mediathekview.mserver.base.utils.UrlUtils;
 import de.mediathekview.mserver.crawler.arte.ArteConstants;
 import de.mediathekview.mserver.crawler.arte.ArteFilmUrlDto;
 import de.mediathekview.mserver.crawler.arte.ArteLanguage;
@@ -11,18 +14,20 @@ import de.mediathekview.mserver.crawler.basic.AbstractRecursiveConverterTask;
 import de.mediathekview.mserver.crawler.basic.TopicUrlDTO;
 
 import javax.ws.rs.client.WebTarget;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.lang.reflect.Type;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class ArteSubcategoryVideosTask extends ArteTaskBase<ArteFilmUrlDto, TopicUrlDTO> {
-
+  private static final Logger LOG = LogManager.getLogger(ArteSubcategoryVideosTask.class);
   private static final Type SENDUNG_OVERVIEW_TYPE_TOKEN =
       new TypeToken<ArteSendungOverviewDto>() {}.getType();
 
-  private final int pageNumber;
   private final ArteLanguage language;
   private final String baseUrl;
 
@@ -30,24 +35,14 @@ public class ArteSubcategoryVideosTask extends ArteTaskBase<ArteFilmUrlDto, Topi
       final AbstractCrawler crawler,
       final Queue<TopicUrlDTO> urlToCrawlDTOs,
       final String baseUrl,
-      final ArteLanguage language,
-      final int pageNumber) {
+      final ArteLanguage language) {
     super(crawler, urlToCrawlDTOs, ArteConstants.AUTH_TOKEN);
 
     registerJsonDeserializer(
         SENDUNG_OVERVIEW_TYPE_TOKEN, new ArteSubcategoryVideosDeserializer(language));
 
     this.baseUrl = baseUrl;
-    this.pageNumber = pageNumber;
     this.language = language;
-  }
-
-  public ArteSubcategoryVideosTask(
-      final AbstractCrawler aCrawler,
-      final Queue<TopicUrlDTO> aUrlToCrawlDtos,
-      final String aBaseUrl,
-      final ArteLanguage aLanguage) {
-    this(aCrawler, aUrlToCrawlDtos, aBaseUrl, aLanguage, 1);
   }
 
   @Override
@@ -55,9 +50,15 @@ public class ArteSubcategoryVideosTask extends ArteTaskBase<ArteFilmUrlDto, Topi
     final ArteSendungOverviewDto result = deserialize(aTarget, SENDUNG_OVERVIEW_TYPE_TOKEN);
     if (result != null) {
       taskResults.addAll(result.getUrls());
-
-      final Optional<String> nextPageId = result.getNextPageId();
-      if (nextPageId.isPresent() && pageNumber < crawler.getCrawlerConfig().getMaximumSubpages()) {
+      //
+      int nextPageId = 0;
+      try {
+        nextPageId = Integer.parseInt(UrlUtils.getUrlParameterValue(aDTO.getUrl(),"page").get());
+      } catch (UrlParseException|NumberFormatException e) {
+        LOG.error("Failed to parse page from url {} error {}",aDTO.getUrl(), e.getMessage());
+      }
+      if (result.getUrls().size() == ArteConstants.SUBCATEGORY_LIMIT 
+          && nextPageId < crawler.getCrawlerConfig().getMaximumSubpages()) {
         // the nextPageId cannot be used to load the next page because authorization is not valid
         // => build new url
         final String url =
@@ -66,7 +67,7 @@ public class ArteSubcategoryVideosTask extends ArteTaskBase<ArteFilmUrlDto, Topi
                 baseUrl,
                 language.getLanguageCode().toLowerCase(),
                 aDTO.getTopic(),
-                pageNumber + 1);
+                nextPageId + 1);
         processNextPage(url, aDTO.getTopic());
       }
     }
@@ -83,6 +84,6 @@ public class ArteSubcategoryVideosTask extends ArteTaskBase<ArteFilmUrlDto, Topi
   protected AbstractRecursiveConverterTask<ArteFilmUrlDto, TopicUrlDTO> createNewOwnInstance(
       final Queue<TopicUrlDTO> aElementsToProcess) {
     return new ArteSubcategoryVideosTask(
-        crawler, aElementsToProcess, baseUrl, language, pageNumber + 1);
+        crawler, aElementsToProcess, baseUrl, language);
   }
 }

--- a/src/main/java/de/mediathekview/mserver/crawler/arte/tasks/ArteTaskBase.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/arte/tasks/ArteTaskBase.java
@@ -41,39 +41,67 @@ public abstract class ArteTaskBase<T, D extends CrawlerUrlDTO> extends AbstractR
     gsonBuilder.registerTypeAdapter(aType, aDeserializer);
   }
 
-  protected <O> Optional<O> deserializeOptional(final WebTarget aTarget, final Type aType) {
-
-    final Gson gson = gsonBuilder.create();
-    final Response response = executeRequest(aTarget);
-    if (response.getStatus() == 200) {
-      final String jsonOutput = response.readEntity(String.class);
-      return gson.fromJson(jsonOutput, aType);
-    } else {
-      LOG.error(
-          "ArteTaskBase: request of url {} failed: {}", aTarget.getUri(), response.getStatus());
+  /**
+   * Try to request a WebTarget resource
+   * Retry 5 time to get the data in case of http error
+   * 404 error is not a reason for retry and null is returned
+   * Mainly this is to take care of ARTE 429 (too many request) response
+   * @param aTarget
+   * @return
+   */
+  protected String requestWebtarget(WebTarget aTarget) {
+    Response response = null;
+    WebTarget webTargetClone = aTarget;
+    int retry = 0;
+    String responseAsString = null;
+    int status = 0;
+    while (retry < 5) {
+      try {
+        response = executeRequest(webTargetClone);
+        status = response.getStatus();
+        if (status == 200) {
+          responseAsString = response.readEntity(String.class);
+          return responseAsString;
+        } else if (status == 404) {
+          LOG.warn(
+              "ArteTaskBase: attempt {} failed 404 for url {}", retry, webTargetClone.getUri().toString());
+          return null;
+        } else {
+          throw new Exception("HTTP: "+status);
+        }
+      } catch (Exception e) {
+        String msg = status + "";
+        if (status == 0) {
+          msg = e.getMessage();
+        }
+        if (retry == 4) {
+          LOG.error("ArteTaskBase: attempt {} failed {} for url {}", retry, msg, webTargetClone.getUri().toString());
+        } else {
+          LOG.warn("ArteTaskBase: attempt {} failed {} for url {}", retry, msg, webTargetClone.getUri().toString());
+        }
+        retry++;       
+      } finally {
+        try {response.close();} catch (Exception e) {}
+      }
+      webTargetClone = createWebTarget(webTargetClone.getUri().toString());
     }
-
+    return responseAsString;
+  }
+  protected <O> Optional<O> deserializeOptional(final WebTarget aTarget, final Type aType) {
+    String inputString = requestWebtarget(aTarget);
+    if (inputString != null) {
+      final Gson gson = gsonBuilder.create();
+      return gson.fromJson(inputString, aType);
+    }
     return Optional.empty();
   }
 
   protected <A> A deserialize(final WebTarget aTarget, final Type aType) {
-
-    final Gson gson = gsonBuilder.create();
-    final Response response;
-    try {
-      response = executeRequest(aTarget);
-    } catch (final Exception e) {
-      LOG.error(e);
-      return null;
+    String inputString = requestWebtarget(aTarget);
+    if (inputString != null) {
+      final Gson gson = gsonBuilder.create();
+      return gson.fromJson(inputString, aType);
     }
-    if (response.getStatus() == 200) {
-      final String jsonOutput = response.readEntity(String.class);
-      return gson.fromJson(jsonOutput, aType);
-    } else {
-      LOG.error(
-          "ArteTaskBase: request of url {} failed: {}", aTarget.getUri(), response.getStatus());
-    }
-
     return null;
   }
 


### PR DESCRIPTION
Der Crawler berücksichtigt die Folgeseiten der Subcategories nicht weil result.getNextPageId immer leer ist.
Man kann nur vermuten, dass es noch weitere Seiten gibt über:
result.getUrls().size() == ArteConstants.SUBCATEGORY_LIMIT
Um die 429 (too many request) abzuschwächen habe ich (wie im alten Crawler) einen retry eingebaut.

Offtopic....
Die PageNumber in dieser Klasse habe ich entfernt weil das so nicht wirklich funktioniert.
Das Task wird für mehrere Subcategories verwendet, was dann dazu führt, dass die PageNumber über die Subcategories hinweg hochgezählt wird (Subcategory A Page 1 / A Page 2 / B Page 3). Eigentlich müsste man vorher die Eingangsqueue splitten und dann pro Subcategory eine Instanz bauen...alles etwas schwierig...
