### PR TITLE
Develop 3sat zdf

### DIFF
--- a/src/main/java/de/mediathekview/mserver/crawler/zdf/json/ZdfDownloadDtoDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/zdf/json/ZdfDownloadDtoDeserializer.java
@@ -142,7 +142,7 @@ public class ZdfDownloadDtoDeserializer implements JsonDeserializer<Optional<Dow
 
   private void parseSubtitle(final DownloadDto dto, final JsonObject rootNode) {
     final JsonArray captionList = rootNode.getAsJsonArray(JSON_ELEMENT_CAPTIONS);
-    if (captionList.size() > 0) {
+    if (captionList != null) {
       final Iterator<JsonElement> captionIterator = captionList.iterator();
       while (captionIterator.hasNext()) {
         final JsonObject caption = captionIterator.next().getAsJsonObject();

--- a/src/main/java/de/mediathekview/mserver/crawler/zdf/json/ZdfDownloadDtoDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/zdf/json/ZdfDownloadDtoDeserializer.java
@@ -142,19 +142,21 @@ public class ZdfDownloadDtoDeserializer implements JsonDeserializer<Optional<Dow
 
   private void parseSubtitle(final DownloadDto dto, final JsonObject rootNode) {
     final JsonArray captionList = rootNode.getAsJsonArray(JSON_ELEMENT_CAPTIONS);
-    final Iterator<JsonElement> captionIterator = captionList.iterator();
-    while (captionIterator.hasNext()) {
-      final JsonObject caption = captionIterator.next().getAsJsonObject();
-      final JsonElement uri = caption.get(JSON_ELEMENT_URI);
-      if (uri != null) {
-        final String uriValue = uri.getAsString();
-
-        // prefer xml subtitles
-        if (uriValue.endsWith(RELEVANT_SUBTITLE_TYPE)) {
-          dto.setSubTitleUrl(uriValue);
-          break;
-        } else if (dto.getSubTitleUrl().isPresent()) {
-          dto.setSubTitleUrl(uriValue);
+    if (captionList.size() > 0) {
+      final Iterator<JsonElement> captionIterator = captionList.iterator();
+      while (captionIterator.hasNext()) {
+        final JsonObject caption = captionIterator.next().getAsJsonObject();
+        final JsonElement uri = caption.get(JSON_ELEMENT_URI);
+        if (uri != null) {
+          final String uriValue = uri.getAsString();
+  
+          // prefer xml subtitles
+          if (uriValue.endsWith(RELEVANT_SUBTITLE_TYPE)) {
+            dto.setSubTitleUrl(uriValue);
+            break;
+          } else if (dto.getSubTitleUrl().isPresent()) {
+            dto.setSubTitleUrl(uriValue);
+          }
         }
       }
     }

--- a/src/main/java/de/mediathekview/mserver/crawler/zdf/json/ZdfFilmDetailDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/zdf/json/ZdfFilmDetailDeserializer.java
@@ -111,7 +111,12 @@ public class ZdfFilmDetailDeserializer implements JsonDeserializer<Optional<ZdfF
     if (mainVideoContent != null) {
       Optional<String> urlOptional =
           JsonUtils.getAttributeAsString(mainVideoContent, JSON_ATTRIBUTE_TEMPLATE);
-
+      // alternative source
+      if (!urlOptional.isPresent()) {
+        if (JsonUtils.checkTreePath(mainVideoContent, Optional.empty() , "streams", "default", JSON_ATTRIBUTE_TEMPLATE)) {
+          urlOptional = JsonUtils.getAttributeAsString(mainVideoContent.getAsJsonObject("streams").getAsJsonObject("default"), JSON_ATTRIBUTE_TEMPLATE);
+        }
+      }
       if (urlOptional.isPresent()) {
         String url = UrlUtils.addDomainIfMissing(urlOptional.get(), apiUrlBase).replace(PLACEHOLDER_PLAYER_ID, PLAYER_ID);
         return Optional.of(url);


### PR DESCRIPTION
Bei 3Sat ist mir aufgefallen, dass viele VideoUrls nicht gefunden werden.
Es fehlt das "ptmd-template". Das segment gibt es nochmal unter Stream. 
Deshalb hier eine Lösung die das Element (wenn nicht vorhanden) aus Streams nimmt.
Beim testen konnte ich keinen Unterschied zwischen den beiden URLs finden.
Dabei ist mir dann aber ein Problem im ZdfFilmDetailDeserializer.java aufgefallen.
Fix auch inkludiert.