### PR TITLE
Develop br

### DIFF
--- a/src/main/java/de/mediathekview/mserver/crawler/br/data/BrID.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/br/data/BrID.java
@@ -28,6 +28,10 @@ public class BrID implements Comparable<BrID>{
       return type;
     }
 
+    public synchronized void setType(BrClipType aType) {
+      this.type = aType;
+    }
+    
     public synchronized String getId() {
       return id;
     }

--- a/src/main/java/de/mediathekview/mserver/crawler/br/json/BrClipDetailsDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/br/json/BrClipDetailsDeserializer.java
@@ -271,6 +271,10 @@ public class BrClipDetailsDeserializer implements JsonDeserializer<Optional<Film
     if (clipDetails.isPresent()) {
       final JsonObject clipDetailRoot = clipDetails.get();
 
+      if (id.getType() == null) {
+        String type = clipDetailRoot.getAsJsonPrimitive(BrGraphQLElementNames.GRAPHQL_TYPE_ELEMENT.getName()).getAsString();
+        this.id.setType(BrClipType.getInstanceByName(type));
+      }
       // Done
       final Optional<String> titel = getTitel(clipDetailRoot);
       final Optional<String> thema = getThema(clipDetailRoot);

--- a/src/main/java/de/mediathekview/mserver/crawler/br/json/BrClipIdsDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/br/json/BrClipIdsDeserializer.java
@@ -54,7 +54,7 @@ public class BrClipIdsDeserializer  implements JsonDeserializer<BrClipCollectIDR
    *         "edges": [
    *           {
    *             "node": {
-   *               "__typename": "Item", <-- could be Item or Programme
+   *               "__typename": "Clip", <-- const. "clip" (in previous version this was "Item" or "Programme") 
    *               "id": "av:584f7f303b4679001197f6b2" <-- Uniq Clip IDs
    *             },
    *             "cursor": "bW9uZ29kYmNvbm5lY3Rpb246MA\u003d\u003d" <-- Cursor to get following Pages. Caution only within the same HTTP-Session

--- a/src/main/java/de/mediathekview/mserver/crawler/br/tasks/BrGetClipIDsTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/br/tasks/BrGetClipIDsTask.java
@@ -83,6 +83,10 @@ public class BrGetClipIDsTask implements Callable<Set<BrID>> {
                   break;
                 }
 
+                if (Thread.currentThread().isInterrupted()) {
+                  break;
+                }
+
               } while (idCollectResult.hasNextPage());
             } else {
               crawler.printErrorMessage();
@@ -93,6 +97,10 @@ public class BrGetClipIDsTask implements Callable<Set<BrID>> {
             startingRequestSize = startingRequestSize * 4 / 5; // 80%
 
             LOG.debug("Anzahl Elemente gemeldet:" + idCollectResult.getResultSize());
+
+            if (Thread.currentThread().isInterrupted()) {
+              break;
+            }
 
           } while (idCollectResult.getClipList().getIds().size() < idCollectResult.getResultSize());
         });


### PR DESCRIPTION
Thread interrupt in der BrGetClipIDsTask.java damit die Schleifen bei einem Crawler-Timeout aufgegeben werden.
Es scheint sich etwas in den Daten der BR Mediathek geändert zu haben.
Der Typename taucht in der Übersicht nur noch als CLIP auf, was kein gültiger Typename. 
Im Anschluss kommt es dann zum NPT beim getThema...
Ich habe jetzt hier eine check eingebaut (der wie im alten Crawler) den Typename, wenn leer, aus dem ClipDetail nimmt.