### PR TITLE
added ApiParams, rename variable for nexxcloud

### DIFF
--- a/MServer-Config.yaml
+++ b/MServer-Config.yaml
@@ -1,7 +1,7 @@
 #### Server configurations ####
 
 # The maximum amount of cpu threads to be used.
-maximumCpuThreads: 16
+maximumCpuThreads: 10
 
 # The maximum duration in minutes the server should run.<br>
 # If set to 0 the server runs without a time limit.
@@ -103,7 +103,6 @@ maximumDaysForSendungVerpasstSectionFuture: 0
 # The time in seconds before a socket connection should time out.
 socketTimeoutInSeconds: 60
 
-
 #### Specific crawler configurations ####
 senderConfigurations:
   ARD:
@@ -139,6 +138,10 @@ senderConfigurations:
   FUNK:
     maximumUrlsPerTask: 99
 
+# configure string variables
+crawlerApiParams:
+  FUNK_REQUEST_TOKEN: 137782e774d7cadc93dcbffbbde0ce9c
+  
 #### COPY ####
 copySettings:
   # En- / disables FTP

--- a/src/main/java/de/mediathekview/mserver/base/config/CrawlerApiParam.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/CrawlerApiParam.java
@@ -1,0 +1,8 @@
+package de.mediathekview.mserver.base.config;
+
+
+public enum CrawlerApiParam {
+  FUNK_REQUEST_TOKEN;
+
+
+}

--- a/src/main/java/de/mediathekview/mserver/base/config/CrawlerUrlType.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/CrawlerUrlType.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 public enum CrawlerUrlType {
   FUNK_WEBSITE("https://www.funk.net"),
   FUNK_API_URL("https://www.funk.net/api/v4.0/"),
-  NEXX_CLUD_API_URL("https://api.nexx.cloud/v3/741");
+  NEXX_CLOUD_API_URL("https://api.nexx.cloud/v3/741");
 
   private URL defaultUrl;
 

--- a/src/main/java/de/mediathekview/mserver/base/config/MServerConfigDTO.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/MServerConfigDTO.java
@@ -32,6 +32,7 @@ public class MServerConfigDTO extends MServerBasicConfigDTO implements ConfigDTO
   private String filmlistImportLocation;
   private MServerLogSettingsDTO logSettings;
   private Map<CrawlerUrlType, URL> crawlerURLs;
+  private Map<CrawlerApiParam, String> crawlerApiParams;
   private Boolean filmlistImporEnabled;
 
   public MServerConfigDTO() {
@@ -95,8 +96,16 @@ public class MServerConfigDTO extends MServerBasicConfigDTO implements ConfigDTO
     return crawlerURLs;
   }
 
+  public Map<CrawlerApiParam, String> getCrawlerApiParams() {
+    return crawlerApiParams;
+  }
+
   public void setCrawlerURLs(final Map<CrawlerUrlType, URL> crawlerURLs) {
     this.crawlerURLs = crawlerURLs;
+  }
+
+  public void setCrawlerApiParams(final Map<CrawlerApiParam, String> pCrawlerApiParams) {
+    this.crawlerApiParams = pCrawlerApiParams;
   }
 
   public Map<FilmlistFormats, String> getFilmlistDiffSavePaths() {
@@ -194,6 +203,13 @@ public class MServerConfigDTO extends MServerBasicConfigDTO implements ConfigDTO
     }
 
     return urlType.getDefaultUrl();
+  }
+
+  public Optional<String> getCrawlerApiParam(final CrawlerApiParam apiParam) {
+    if (crawlerApiParams.containsKey(apiParam)) {
+      return Optional.of(crawlerApiParams.get(apiParam));
+    }
+    return Optional.empty();
   }
 
   public Boolean getWriteFilmlistHashFileEnabled() {
@@ -298,4 +314,9 @@ public class MServerConfigDTO extends MServerBasicConfigDTO implements ConfigDTO
   public URL putCrawlerUrl(final CrawlerUrlType key, final URL value) {
     return crawlerURLs.put(key, value);
   }
+
+  public String putCrawlerApiParam(final CrawlerApiParam key, final String value) {
+    return crawlerApiParams.put(key, value);
+  }
+
 }

--- a/src/main/java/de/mediathekview/mserver/crawler/funk/FunkUrls.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/funk/FunkUrls.java
@@ -12,9 +12,9 @@ public enum FunkUrls {
   /** [website]/channel/[channelAlias]/[alias] */
   WEBSITE(CrawlerUrlType.FUNK_WEBSITE, "%s/channel/%s/%s"),
   /** [ApiBaseUrl]/session/init */
-  NEXX_CLOUD_SESSION_INIT(CrawlerUrlType.NEXX_CLUD_API_URL, "%s/session/init"),
+  NEXX_CLOUD_SESSION_INIT(CrawlerUrlType.NEXX_CLOUD_API_URL, "%s/session/init"),
   /** [ApiBaseUrl]/videos/byid/[videoId] */
-  NEXX_CLOUD_VIDEO(CrawlerUrlType.NEXX_CLUD_API_URL, "%s/videos/byid/%s");
+  NEXX_CLOUD_VIDEO(CrawlerUrlType.NEXX_CLOUD_API_URL, "%s/videos/byid/%s");
 
   private final String urlTemplate;
   private final CrawlerUrlType baseUrlUrlType;

--- a/src/main/java/de/mediathekview/mserver/crawler/funk/tasks/FunkVideosToFilmsTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/funk/tasks/FunkVideosToFilmsTask.java
@@ -43,7 +43,7 @@ public class FunkVideosToFilmsTask
       @Nullable final String authKey) {
     super(crawler, filmInfos, authKey);
     this.sessionId = new NexxCloudSessionInitiationTask(crawler).call();
-    this.REQUEST_TOKEN = crawler.getRuntimeConfig().getCrawlerApiParam(CrawlerApiParam.FUNK_REQUEST_TOKEN).get();
+    this.REQUEST_TOKEN = crawler.getRuntimeConfig().getCrawlerApiParam(CrawlerApiParam.FUNK_REQUEST_TOKEN).orElse("");
     this.channels = channels;
   }
 

--- a/src/main/java/de/mediathekview/mserver/crawler/funk/tasks/FunkVideosToFilmsTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/funk/tasks/FunkVideosToFilmsTask.java
@@ -3,6 +3,7 @@ package de.mediathekview.mserver.crawler.funk.tasks;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.reflect.TypeToken;
 import de.mediathekview.mlib.daten.*;
+import de.mediathekview.mserver.base.config.CrawlerApiParam;
 import de.mediathekview.mserver.crawler.basic.AbstractCrawler;
 import de.mediathekview.mserver.crawler.basic.AbstractJsonRestTask;
 import de.mediathekview.mserver.crawler.basic.FilmInfoDto;
@@ -31,7 +32,7 @@ public class FunkVideosToFilmsTask
   private static final String POST_FORM_FIELD_VALUE_ONE = "1";
   private static final String HEADER_X_REQUEST_CID = "x-request-cid";
   private static final String HEADER_X_REQUEST_TOKEN = "x-request-token";
-  private static final String REQUEST_TOKEN = "137782e774d7cadc93dcbffbbde0ce9c";
+  private String REQUEST_TOKEN = "";
   private Long sessionId;
   private final Map<String, FunkChannelDTO> channels;
 
@@ -42,6 +43,7 @@ public class FunkVideosToFilmsTask
       @Nullable final String authKey) {
     super(crawler, filmInfos, authKey);
     this.sessionId = new NexxCloudSessionInitiationTask(crawler).call();
+    this.REQUEST_TOKEN = crawler.getRuntimeConfig().getCrawlerApiParam(CrawlerApiParam.FUNK_REQUEST_TOKEN).get();
     this.channels = channels;
   }
 

--- a/src/test/java/de/mediathekview/mserver/crawler/funk/NexxCloudSessionInitiationTaskTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/funk/NexxCloudSessionInitiationTaskTest.java
@@ -60,19 +60,19 @@ public class NexxCloudSessionInitiationTaskTest extends FunkTaskTestBase {
     rootConfig
         .getConfig()
         .putCrawlerUrl(
-            CrawlerUrlType.NEXX_CLUD_API_URL, new URL(getWireMockBaseUrlSafe() + "/v3/741"));
+            CrawlerUrlType.NEXX_CLOUD_API_URL, new URL(getWireMockBaseUrlSafe() + "/v3/741"));
   }
 
   @After
   public void tearDown() {
-    CrawlerUrlType.NEXX_CLUD_API_URL
+    CrawlerUrlType.NEXX_CLOUD_API_URL
         .getDefaultUrl()
         .ifPresent(
             url ->
                 crawler
                     .getRuntimeConfig()
                     .getCrawlerURLs()
-                    .put(CrawlerUrlType.NEXX_CLUD_API_URL, url));
+                    .put(CrawlerUrlType.NEXX_CLOUD_API_URL, url));
   }
 
   private Long executeTask() {

--- a/src/test/resources/MServer-JUnit-Config.yaml
+++ b/src/test/resources/MServer-JUnit-Config.yaml
@@ -22,6 +22,10 @@ senderIncluded:
 #        duration: 12
 #        unit: HOURS
 
+# configure string variables
+crawlerApiParams:
+  FUNK_REQUEST_TOKEN: 137782e774d7cadc93dcbffbbde0ce9c
+
 # The formats in which the filmlist should be saved to.
 # Possible are: JSON, OLD_JSON, JSON_COMPRESSED_XZ, OLD_JSON_COMPRESSED_XZ
 filmlistSaveFormats:


### PR DESCRIPTION
Mit diesem PR können variable über die Konfigdatei des crawler hinzugefügt werden.
Hier erstmal exemplarisch für einen Token der sich in den letzten 3 Monaten geändert hatte.
Später können dann andere parameter folgen.