### PR TITLE
zdf: add topics search

### DIFF
--- a/src/main/java/mServer/crawler/sender/zdf/ZdfConstants.java
+++ b/src/main/java/mServer/crawler/sender/zdf/ZdfConstants.java
@@ -12,6 +12,8 @@ public final class ZdfConstants {
 
   public static final String URL_HTML_DAY = URL_BASE + "/sendung-verpasst?airtimeDate=%s";
 
+  public static final String URL_TOPICS = URL_BASE + "/sendungen-a-z";
+
   /** Base url of the ZDF api. */
   public static final String URL_API_BASE = "https://api.zdf.de";
 

--- a/src/main/java/mServer/crawler/sender/zdf/ZdfCrawler.java
+++ b/src/main/java/mServer/crawler/sender/zdf/ZdfCrawler.java
@@ -1,16 +1,23 @@
 package mServer.crawler.sender.zdf;
 
+import de.mediathekview.mlib.Config;
 import de.mediathekview.mlib.Const;
+import de.mediathekview.mlib.tool.Log;
 import mServer.crawler.FilmeSuchen;
 import mServer.crawler.sender.base.CrawlerUrlDTO;
 import mServer.crawler.sender.base.JsoupConnection;
 import mServer.crawler.sender.zdf.tasks.ZdfDayPageHtmlTask;
+import mServer.crawler.sender.zdf.tasks.ZdfLetterListHtmlTask;
+import mServer.crawler.sender.zdf.tasks.ZdfTopicPageHtmlTask;
+import mServer.crawler.sender.zdf.tasks.ZdfTopicsPageHtmlTask;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 
@@ -35,6 +42,40 @@ public class ZdfCrawler extends AbstractZdfCrawler {
   @Override
   protected @NotNull String getUrlDay() {
     return ZdfConstants.URL_DAY;
+  }
+
+  @Override
+  public Queue<CrawlerUrlDTO> getTopicsEntries() throws ExecutionException, InterruptedException {
+
+    final ConcurrentLinkedQueue<CrawlerUrlDTO> shows = new ConcurrentLinkedQueue<>();
+
+    final ConcurrentLinkedQueue<CrawlerUrlDTO> letterListUrl = new ConcurrentLinkedQueue<>();
+    letterListUrl.add(new CrawlerUrlDTO(ZdfConstants.URL_TOPICS));
+
+    final ZdfLetterListHtmlTask letterTask = new ZdfLetterListHtmlTask(this, letterListUrl);
+    final Set<CrawlerUrlDTO> letterUrls = forkJoinPool.submit(letterTask).get();
+
+    Log.sysLog("ZDF: letters: " + letterUrls.size());
+
+    if (Config.getStop()) {
+      return shows;
+    }
+
+    final ZdfTopicsPageHtmlTask topicsTask =
+            new ZdfTopicsPageHtmlTask(this, new ConcurrentLinkedQueue<>(letterUrls));
+    final Set<CrawlerUrlDTO> topicsUrls = forkJoinPool.submit(topicsTask).get();
+
+    Log.sysLog("ZDF: topics: " + topicsUrls.size());
+
+    if (Config.getStop()) {
+      return shows;
+    }
+
+    final ZdfTopicPageHtmlTask topicTask =
+            new ZdfTopicPageHtmlTask(this, new ConcurrentLinkedQueue<>(topicsUrls));
+    shows.addAll(forkJoinPool.submit(topicTask).get());
+
+    return shows;
   }
 
   @Override

--- a/src/main/java/mServer/crawler/sender/zdf/parser/ZdfLetterListHtmlDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/zdf/parser/ZdfLetterListHtmlDeserializer.java
@@ -1,0 +1,30 @@
+package mServer.crawler.sender.zdf.parser;
+
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.base.UrlUtils;
+import mServer.crawler.sender.zdf.ZdfConstants;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ZdfLetterListHtmlDeserializer {
+  private static final String LINK_SELECTOR = "ul.letter-list li a";
+  private static final String ATTRIBUTE_HREF = "href";
+
+  public Set<CrawlerUrlDTO> deserialize(final Document document) {
+    final Set<CrawlerUrlDTO> results = new HashSet<>();
+
+    Elements filmUrls = document.select(LINK_SELECTOR);
+    filmUrls.forEach(
+            filmUrlElement -> {
+              String url = filmUrlElement.attr(ATTRIBUTE_HREF);
+              url = UrlUtils.addDomainIfMissing(url, ZdfConstants.URL_BASE);
+              results.add(new CrawlerUrlDTO(url));
+            });
+
+    return results;
+  }
+
+}

--- a/src/main/java/mServer/crawler/sender/zdf/parser/ZdfTopicPageHtmlDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/zdf/parser/ZdfTopicPageHtmlDeserializer.java
@@ -1,0 +1,145 @@
+package mServer.crawler.sender.zdf.parser;
+
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.base.UrlParseException;
+import mServer.crawler.sender.base.UrlUtils;
+import mServer.crawler.sender.zdf.ZdfConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class ZdfTopicPageHtmlDeserializer {
+  private static final Logger LOG = LogManager.getLogger(ZdfTopicPageHtmlDeserializer.class);
+  private static final String HEADLINES = "article.b-cluster";
+  private static final String HEADLINES2 = "section.b-content-teaser-list";
+  private static final String LINK_SELECTOR1 = "article.b-content-teaser-item h3 a";
+  private static final String LINK_SELECTOR2 = "article.b-cluster-teaser h3 a";
+  private static final String TEASER_SELECTOR = "div.b-cluster-teaser.lazyload";
+  private static final String MAIN_VIDEO_SELECTOR = "div.b-playerbox";
+
+  private static final String[] BLACKLIST_HEADLINES =
+          new String[]{
+                  "Comedy",
+                  "neoriginal",
+                  "Komödien",
+                  "Beliebte ",
+                  "Mehr zum Herzkino",
+                  "Mehr Samstagskrimis",
+                  "Mehr tolle Filme",
+                  "Mehr zum Thema",
+                  "Mehr zur SOKO",
+                  "Mehr Talk und Show",
+                  "Mehr ZDFkultur",
+                  "Mehr bei ZDFkultur",
+                  "Mehr von ZDFkultur",
+                  "Mehr Unterhaltung in Spielfilmlänge",
+                  "Mehr Doku-Themen",
+                  "Mehr Wissenssendungen",
+                  "Mehr Bier",
+                  "Mehr Zweiteiler",
+                  "Mehr Wissenschaft",
+                  "Mehr Quiz und Show",
+                  "Krimis",
+                  "Shows",
+                  "Weitere Dokus",
+                  "True Crime",
+                  "- Kommissare",
+                  "-Serien",
+                  "Spannung in Spielfilmlänge",
+                  "Reihen am",
+                  "Weitere Fernsehfilme",
+                  "Weitere funk",
+                  "Die Welt von",
+                  "Weitere Filme",
+                  "Alle Samstagskrimis",
+                  "Alle Freitagskrimis",
+                  "Alle SOKOs",
+                  "Weitere SOKOs",
+                  "Weitere Thriller",
+                  "Direkt zu",
+                  "Das könnte",
+                  "Auch interessant",
+                  "Alle Herzkino",
+                  "Film-Highlights"
+          };
+  private static final String ATTRIBUTE_HREF = "href";
+
+  private final String urlApiBase;
+
+  public ZdfTopicPageHtmlDeserializer(final String urlApiBase) {
+    this.urlApiBase = urlApiBase;
+  }
+
+  public Set<CrawlerUrlDTO> deserialize(final Document document) {
+    final Set<CrawlerUrlDTO> results = new HashSet<>();
+
+    final Elements mainVideos = document.select(MAIN_VIDEO_SELECTOR);
+    mainVideos.forEach(
+            mainVideo -> {
+              final String id = mainVideo.attr("data-zdfplayer-id");
+              if (id != null) {
+                final String url = String.format(ZdfConstants.URL_FILM_JSON, urlApiBase, id);
+                results.add(new CrawlerUrlDTO(url));
+              }
+            });
+
+    final Elements headlines = document.select(HEADLINES);
+    headlines.addAll(document.select(HEADLINES2));
+    headlines.forEach(
+            headline -> {
+              Element x = headline.select("h2").first();
+              if (x != null) {
+
+                if (Arrays.stream(BLACKLIST_HEADLINES)
+                        .noneMatch(blacklistEntry -> x.text().contains(blacklistEntry))) {
+
+                  parseHeadline(results, headline);
+                }
+              } else {
+                parseHeadline(results, headline);
+              }
+            });
+
+    return results;
+  }
+
+  private void parseHeadline(Set<CrawlerUrlDTO> results, Element headline) {
+    Elements filmUrls = headline.select(LINK_SELECTOR1);
+    filmUrls.addAll(headline.select(LINK_SELECTOR2));
+    filmUrls.forEach(
+            filmUrlElement -> {
+              final String href = filmUrlElement.attr(ATTRIBUTE_HREF);
+              final Optional<String> url = buildFilmUrlJsonFromHtmlLink(href);
+              url.ifPresent(u -> results.add(new CrawlerUrlDTO(u)));
+            });
+
+    Elements teasers = headline.select(TEASER_SELECTOR);
+    teasers.forEach(
+            teaserElement -> {
+              final String teaserUrl = teaserElement.attr("data-teaser-xhr-url");
+              final Optional<String> sophoraId;
+              try {
+                sophoraId = UrlUtils.getUrlParameterValue(teaserUrl, "sophoraId");
+                sophoraId.ifPresent(
+                        s ->
+                                results.add(
+                                        new CrawlerUrlDTO(
+                                                String.format(ZdfConstants.URL_FILM_JSON, urlApiBase, s))));
+              } catch (UrlParseException e) {
+                LOG.error(e);
+              }
+            });
+  }
+
+  private Optional<String> buildFilmUrlJsonFromHtmlLink(String attr) {
+    return UrlUtils.getFileName(attr)
+            .map(s -> String.format(ZdfConstants.URL_FILM_JSON, urlApiBase, s.split("\\.")[0]));
+  }
+}

--- a/src/main/java/mServer/crawler/sender/zdf/parser/ZdfTopicsPageHtmlDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/zdf/parser/ZdfTopicsPageHtmlDeserializer.java
@@ -1,0 +1,30 @@
+package mServer.crawler.sender.zdf.parser;
+
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.base.UrlUtils;
+import mServer.crawler.sender.zdf.ZdfConstants;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ZdfTopicsPageHtmlDeserializer {
+
+  private static final String LINK_SELECTOR = "article h3 a";
+  private static final String ATTRIBUTE_HREF = "href";
+
+  public Set<CrawlerUrlDTO> deserialize(final Document document) {
+    final Set<CrawlerUrlDTO> results = new HashSet<>();
+
+    Elements filmUrls = document.select(LINK_SELECTOR);
+    filmUrls.forEach(
+            filmUrlElement -> {
+              String url = filmUrlElement.attr(ATTRIBUTE_HREF);
+              url = UrlUtils.addDomainIfMissing(url, ZdfConstants.URL_BASE);
+              results.add(new CrawlerUrlDTO(url));
+            });
+
+    return results;
+  }
+}

--- a/src/main/java/mServer/crawler/sender/zdf/tasks/ZdfLetterListHtmlTask.java
+++ b/src/main/java/mServer/crawler/sender/zdf/tasks/ZdfLetterListHtmlTask.java
@@ -1,0 +1,33 @@
+package mServer.crawler.sender.zdf.tasks;
+
+import mServer.crawler.sender.MediathekReader;
+import mServer.crawler.sender.base.AbstractDocumentTask;
+import mServer.crawler.sender.base.AbstractRecursivConverterTask;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.zdf.parser.ZdfLetterListHtmlDeserializer;
+import org.jsoup.nodes.Document;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ZdfLetterListHtmlTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
+
+  private final transient ZdfLetterListHtmlDeserializer letterListDeserializer;
+
+  public ZdfLetterListHtmlTask(
+          final MediathekReader crawler, final ConcurrentLinkedQueue<CrawlerUrlDTO> urlToCrawlDTOs) {
+    super(crawler, urlToCrawlDTOs);
+    letterListDeserializer = new ZdfLetterListHtmlDeserializer();
+  }
+
+  @Override
+  protected void processDocument(final CrawlerUrlDTO aUrlDTO, final Document aDocument) {
+    taskResults.addAll(letterListDeserializer.deserialize(aDocument));
+  }
+
+  @Override
+  protected AbstractRecursivConverterTask<CrawlerUrlDTO, CrawlerUrlDTO> createNewOwnInstance(
+          final ConcurrentLinkedQueue<CrawlerUrlDTO> aElementsToProcess) {
+    return new ZdfLetterListHtmlTask(crawler, aElementsToProcess);
+  }
+}

--- a/src/main/java/mServer/crawler/sender/zdf/tasks/ZdfTopicPageHtmlTask.java
+++ b/src/main/java/mServer/crawler/sender/zdf/tasks/ZdfTopicPageHtmlTask.java
@@ -1,0 +1,33 @@
+package mServer.crawler.sender.zdf.tasks;
+
+import mServer.crawler.sender.MediathekReader;
+import mServer.crawler.sender.base.AbstractDocumentTask;
+import mServer.crawler.sender.base.AbstractRecursivConverterTask;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.zdf.ZdfConstants;
+import mServer.crawler.sender.zdf.parser.ZdfTopicPageHtmlDeserializer;
+import org.jsoup.nodes.Document;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ZdfTopicPageHtmlTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
+
+  private final transient ZdfTopicPageHtmlDeserializer topicsDeserializer;
+
+  public ZdfTopicPageHtmlTask(
+          final MediathekReader crawler, final ConcurrentLinkedQueue<CrawlerUrlDTO> urlToCrawlDTOs) {
+    super(crawler, urlToCrawlDTOs);
+    topicsDeserializer = new ZdfTopicPageHtmlDeserializer(ZdfConstants.URL_API_BASE);
+  }
+
+  @Override
+  protected void processDocument(final CrawlerUrlDTO aUrlDTO, final Document aDocument) {
+    taskResults.addAll(topicsDeserializer.deserialize(aDocument));
+  }
+
+  @Override
+  protected AbstractRecursivConverterTask<CrawlerUrlDTO, CrawlerUrlDTO> createNewOwnInstance(
+          final ConcurrentLinkedQueue<CrawlerUrlDTO> aElementsToProcess) {
+    return new ZdfTopicPageHtmlTask(crawler, aElementsToProcess);
+  }
+}

--- a/src/main/java/mServer/crawler/sender/zdf/tasks/ZdfTopicsPageHtmlTask.java
+++ b/src/main/java/mServer/crawler/sender/zdf/tasks/ZdfTopicsPageHtmlTask.java
@@ -1,0 +1,32 @@
+package mServer.crawler.sender.zdf.tasks;
+
+import mServer.crawler.sender.MediathekReader;
+import mServer.crawler.sender.base.AbstractDocumentTask;
+import mServer.crawler.sender.base.AbstractRecursivConverterTask;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.zdf.parser.ZdfTopicsPageHtmlDeserializer;
+import org.jsoup.nodes.Document;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ZdfTopicsPageHtmlTask extends AbstractDocumentTask<CrawlerUrlDTO, CrawlerUrlDTO> {
+
+  private final transient ZdfTopicsPageHtmlDeserializer topicsDeserializer;
+
+  public ZdfTopicsPageHtmlTask(
+          final MediathekReader crawler, final ConcurrentLinkedQueue<CrawlerUrlDTO> urlToCrawlDTOs) {
+    super(crawler, urlToCrawlDTOs);
+    topicsDeserializer = new ZdfTopicsPageHtmlDeserializer();
+  }
+
+  @Override
+  protected void processDocument(final CrawlerUrlDTO aUrlDTO, final Document aDocument) {
+    taskResults.addAll(topicsDeserializer.deserialize(aDocument));
+  }
+
+  @Override
+  protected AbstractRecursivConverterTask<CrawlerUrlDTO, CrawlerUrlDTO> createNewOwnInstance(
+          final ConcurrentLinkedQueue<CrawlerUrlDTO> aElementsToProcess) {
+    return new ZdfTopicsPageHtmlTask(crawler, aElementsToProcess);
+  }
+}


### PR DESCRIPTION
in der ZDF-Mediathek wird jetzt der Bereich "Sendungen A-Z" zusätzlich durchsucht, wenn ein langer Lauf ausgeführt wird.
Dies hat zur Folge, dass knapp die doppelte Menge an ZDF-Sendungen gefunden wird.
Löst die Probleme mit alten Sendungen, die in MV nicht (mehr) zu finden sind aber in der ZDF-Mediathek vorhanden sind.

Ich vermute, dass wird die Laufzeit des ZDF-Crawlers ungefähr verdoppeln. Nach den aktuellen Logs wird der lange Lauf wohl ca. 20 Minuten länger laufen. ZDF wird dann wohl der letzte sein, nicht mehr ARTE.