### PR TITLE
ARD: load all retro subpages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 group = 'de.mediathekview'
 archivesBaseName = "MServer"
-version = '3.1.186'
+version = '3.1.187'
 
 def jarName = 'MServer.jar'
 def mainClass = 'mServer.Main'

--- a/src/main/java/mServer/crawler/sender/ard/ArdTopicInfoDto.java
+++ b/src/main/java/mServer/crawler/sender/ard/ArdTopicInfoDto.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 public class ArdTopicInfoDto {
   private final Set<ArdFilmInfoDto> filmInfos;
+  private String id;
   private int subPageNumber;
   private int maxSubPageNumber;
 
@@ -16,6 +17,14 @@ public class ArdTopicInfoDto {
 
   public Set<ArdFilmInfoDto> getFilmInfos() {
     return filmInfos;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
   }
 
   public int getSubPageNumber() {
@@ -39,11 +48,11 @@ public class ArdTopicInfoDto {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ArdTopicInfoDto that = (ArdTopicInfoDto) o;
-    return subPageNumber == that.subPageNumber && maxSubPageNumber == that.maxSubPageNumber && Objects.equals(filmInfos, that.filmInfos);
+    return Objects.equals(id, that.id) && subPageNumber == that.subPageNumber && maxSubPageNumber == that.maxSubPageNumber && Objects.equals(filmInfos, that.filmInfos);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(filmInfos, subPageNumber, maxSubPageNumber);
+    return Objects.hash(id, filmInfos, subPageNumber, maxSubPageNumber);
   }
 }

--- a/src/main/java/mServer/crawler/sender/ard/ArdTopicInfoDto.java
+++ b/src/main/java/mServer/crawler/sender/ard/ArdTopicInfoDto.java
@@ -1,0 +1,49 @@
+package mServer.crawler.sender.ard;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class ArdTopicInfoDto {
+  private final Set<ArdFilmInfoDto> filmInfos;
+  private int subPageNumber;
+  private int maxSubPageNumber;
+
+  public ArdTopicInfoDto(final Set<ArdFilmInfoDto> filmInfos) {
+    this.filmInfos = filmInfos;
+    subPageNumber = 0;
+    maxSubPageNumber = 0;
+  }
+
+  public Set<ArdFilmInfoDto> getFilmInfos() {
+    return filmInfos;
+  }
+
+  public int getSubPageNumber() {
+    return subPageNumber;
+  }
+
+  public void setSubPageNumber(final int subPageNumber) {
+    this.subPageNumber = subPageNumber;
+  }
+
+  public int getMaxSubPageNumber() {
+    return maxSubPageNumber;
+  }
+
+  public void setMaxSubPageNumber(final int maxSubPageNumber) {
+    this.maxSubPageNumber = maxSubPageNumber;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ArdTopicInfoDto that = (ArdTopicInfoDto) o;
+    return subPageNumber == that.subPageNumber && maxSubPageNumber == that.maxSubPageNumber && Objects.equals(filmInfos, that.filmInfos);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filmInfos, subPageNumber, maxSubPageNumber);
+  }
+}

--- a/src/main/java/mServer/crawler/sender/ard/json/ArdTopicPageDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/ard/json/ArdTopicPageDeserializer.java
@@ -1,30 +1,58 @@
 package mServer.crawler.sender.ard.json;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
+import com.google.gson.*;
+import mServer.crawler.sender.ard.ArdFilmInfoDto;
+import mServer.crawler.sender.ard.ArdTopicInfoDto;
 
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
-import mServer.crawler.sender.ard.ArdFilmInfoDto;
 
 public class ArdTopicPageDeserializer extends ArdTeasersDeserializer
-        implements JsonDeserializer<Set<ArdFilmInfoDto>> {
+        implements JsonDeserializer<ArdTopicInfoDto> {
 
   private static final String ELEMENT_TEASERS = "teasers";
+  private static final String ELEMENT_PAGE_NUMBER = "pageNumber";
+  private static final String ELEMENT_TOTAL_ELEMENTS = "totalElements";
+  private static final String ELEMENT_PAGE_SIZE = "pageSize";
+  private static final String ELEMENT_PAGINATION = "pagination";
 
   @Override
-  public Set<ArdFilmInfoDto> deserialize(
-          final JsonElement jsonElement, final Type type, final JsonDeserializationContext context) {
+  public ArdTopicInfoDto deserialize(
+          final JsonElement showPageElement, final Type type, final JsonDeserializationContext context) {
     final Set<ArdFilmInfoDto> results = new HashSet<>();
+    final ArdTopicInfoDto ardTopicInfoDto = new ArdTopicInfoDto(results);
 
-    if (jsonElement.getAsJsonObject().has(ELEMENT_TEASERS)) {
-      JsonArray teasers = jsonElement.getAsJsonObject().get(ELEMENT_TEASERS).getAsJsonArray();
+    final JsonObject showPageObject = showPageElement.getAsJsonObject();
+    if (showPageObject.has(ELEMENT_TEASERS)) {
+      final JsonArray teasers = showPageObject.get(ELEMENT_TEASERS).getAsJsonArray();
       results.addAll(parseTeasers(teasers));
     }
 
-    return results;
+    final JsonElement paginationElement = showPageObject.get(ELEMENT_PAGINATION);
+    ardTopicInfoDto.setSubPageNumber(
+            getChildElementAsIntOrNullIfNotExist(paginationElement, ELEMENT_PAGE_NUMBER));
+    final int totalElements = getChildElementAsIntOrNullIfNotExist(paginationElement, ELEMENT_TOTAL_ELEMENTS);
+    final int pageSize = getChildElementAsIntOrNullIfNotExist(paginationElement, ELEMENT_PAGE_SIZE);
+    ardTopicInfoDto.setMaxSubPageNumber(pageSize == 0 ? 0 :
+            (totalElements + pageSize - 1) / pageSize);
+
+    return ardTopicInfoDto;
+  }
+
+  private int getChildElementAsIntOrNullIfNotExist(
+          final JsonElement parentElement, final String childElementName) {
+    if (parentElement == null || parentElement.isJsonNull()) {
+      return 0;
+    }
+    return getJsonElementAsIntOrNullIfNotExist(
+            parentElement.getAsJsonObject().get(childElementName));
+  }
+
+  private int getJsonElementAsIntOrNullIfNotExist(final JsonElement element) {
+    if (element.isJsonNull()) {
+      return 0;
+    }
+    return element.getAsInt();
   }
 }

--- a/src/main/java/mServer/crawler/sender/ard/json/ArdTopicPageDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/ard/json/ArdTopicPageDeserializer.java
@@ -3,14 +3,17 @@ package mServer.crawler.sender.ard.json;
 import com.google.gson.*;
 import mServer.crawler.sender.ard.ArdFilmInfoDto;
 import mServer.crawler.sender.ard.ArdTopicInfoDto;
+import mServer.crawler.sender.base.JsonUtils;
 
 import java.lang.reflect.Type;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public class ArdTopicPageDeserializer extends ArdTeasersDeserializer
         implements JsonDeserializer<ArdTopicInfoDto> {
 
+  private static final String ELEMENT_ID = "id";
   private static final String ELEMENT_TEASERS = "teasers";
   private static final String ELEMENT_PAGE_NUMBER = "pageNumber";
   private static final String ELEMENT_TOTAL_ELEMENTS = "totalElements";
@@ -28,6 +31,8 @@ public class ArdTopicPageDeserializer extends ArdTeasersDeserializer
       final JsonArray teasers = showPageObject.get(ELEMENT_TEASERS).getAsJsonArray();
       results.addAll(parseTeasers(teasers));
     }
+    final Optional<String> id = JsonUtils.getAttributeAsString(showPageObject, ELEMENT_ID);
+    id.ifPresent(ardTopicInfoDto::setId);
 
     final JsonElement paginationElement = showPageObject.get(ELEMENT_PAGINATION);
     ardTopicInfoDto.setSubPageNumber(

--- a/src/main/java/mServer/crawler/sender/ard/tasks/ArdTopicPageTask.java
+++ b/src/main/java/mServer/crawler/sender/ard/tasks/ArdTopicPageTask.java
@@ -13,6 +13,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -26,6 +28,41 @@ public class ArdTopicPageTask extends ArdTaskBase<ArdFilmInfoDto, CrawlerUrlDTO>
   private static final String PAGE_NUMBER = "pageNumber";
   private static final String URL_PAGE_NUMBER_REPLACE_REGEX = PAGE_NUMBER + "%22%3A\\d+";
   private static final String PAGE_NUMBER_URL_ENCODED = PAGE_NUMBER + "%22%3A";
+
+  private static final Set<String> TOPICS_LOAD_ALL_PAGES = new HashSet<>();
+
+  static {
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3N3ci5kZS8yNDEwMzE1Ng");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3N3ci5kZS9zZGIvc3RJZC8xMzM3");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3N3ci5kZS9zZGIvc3RJZC8xMjY4");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3N3ci5kZS9zZGIvc3RJZC8xMzA1");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3N3ci5kZS8yNDEwMzIzNA");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3N3ci5kZS8yNDEwMzAzNA");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL2JyLmRlL2Jyb2FkY2FzdFNlcmllcy8yOGEwMzU4Yi00N2ViLTQ0MDktOGFmZi02ZjVkMDE5NDA2NDc");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL2JyLmRlL2Jyb2FkY2FzdFNlcmllcy8wYTNlMzRiYy01OWRhLTRjY2UtOTJlOS01MTAxMjAzZmMzMWM");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3dkci5kZS93ZHJyZXRybw");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3dkci5kZS93ZHJyZXRyb3NwZXppYWw");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3dkci5kZS93ZHJyZXRyb3Nwb3J0");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3NyLW9ubGluZS5kZS9SRVRSTy1BUw");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3NyLW9ubGluZS5kZS9SRVRSTy1EU0Q");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3NyLW9ubGluZS5kZS9SRVRSTy1IRA");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3NyLW9ubGluZS5kZS9SRVRSTy1JRA");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3NyLW9ubGluZS5kZS9SRVRSTy1XTQ");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi5kZS9ha3R1ZWxsZXMtbWFnYXppbg");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi5kZS9iZXJpY2h0ZS1kb2t1cy1yZXBvcnRhZ2Vu");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi5kZS9iZXJsaW4tc3RlbGx0LXZvcg");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi1vbmxpbmUuZGUvYmVybGluZXItYWJlbmRzY2hhdQ");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi5kZS9kYXMtcHJvZmls");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi5kZS9tb3NhaWs");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JiYi5kZS93aWUtaWNoLWFuZ2VmYW5nZW4taGFiZQ");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL25kci5kZS80NTkx");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL25kci5kZS80NTg3");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL2hyLW9ubGluZS8zODIyMDA5Nw");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL2hyLW9ubGluZS8zODIyMDEzNQ");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL2hyLW9ubGluZS8zODIyMDA5NQ");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL2hyLW9ubGluZS8zODIyMDA5Ng");
+    TOPICS_LOAD_ALL_PAGES.add("Y3JpZDovL3JhZGlvYnJlbWVuLmRlL2IwYTJlZWFlLWI2NjAtNDI5Yi05ZTE3LTM5YzlkZDhmNTc4Ng");
+  }
 
   public ArdTopicPageTask(MediathekReader aCrawler,
                           ConcurrentLinkedQueue<CrawlerUrlDTO> aUrlToCrawlDtos) {
@@ -59,7 +96,7 @@ public class ArdTopicPageTask extends ArdTaskBase<ArdFilmInfoDto, CrawlerUrlDTO>
     final ConcurrentLinkedQueue<CrawlerUrlDTO> subpages = new ConcurrentLinkedQueue<>();
 
     final int actualSubPageNumber = topicInfo.getSubPageNumber();
-    final int maximumAllowedSubpages = getMaximumSubpages();
+    final int maximumAllowedSubpages = getMaximumSubpages(topicInfo.getId());
     if (actualSubPageNumber != 0) {
       LOG.debug("Sub page {} is already the maximum allowed sub page.", actualSubPageNumber);
       return subpages;
@@ -86,7 +123,10 @@ public class ArdTopicPageTask extends ArdTaskBase<ArdFilmInfoDto, CrawlerUrlDTO>
     return subpages;
   }
 
-  private int getMaximumSubpages() {
+  private int getMaximumSubpages(String id) {
+    if (TOPICS_LOAD_ALL_PAGES.contains(id)) {
+      return 999;
+    }
     return 0;
   }
 

--- a/src/main/java/mServer/crawler/sender/ard/tasks/ArdTopicPageTask.java
+++ b/src/main/java/mServer/crawler/sender/ard/tasks/ArdTopicPageTask.java
@@ -2,26 +2,36 @@ package mServer.crawler.sender.ard.tasks;
 
 import com.google.gson.reflect.TypeToken;
 import de.mediathekview.mlib.Config;
-import java.lang.reflect.Type;
-import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import jakarta.ws.rs.client.WebTarget;
 import mServer.crawler.sender.MediathekReader;
 import mServer.crawler.sender.ard.ArdFilmInfoDto;
+import mServer.crawler.sender.ard.ArdTopicInfoDto;
 import mServer.crawler.sender.ard.json.ArdTopicPageDeserializer;
-import mServer.crawler.sender.base.CrawlerUrlDTO;
 import mServer.crawler.sender.base.AbstractRecursivConverterTask;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ArdTopicPageTask extends ArdTaskBase<ArdFilmInfoDto, CrawlerUrlDTO> {
+  private static final Logger LOG = LogManager.getLogger(ArdTopicPageTask.class);
 
-  private static final Type SET_FILMINFO_TYPE_TOKEN = new TypeToken<Set<ArdFilmInfoDto>>() {
-  }.getType();
+  private static final Type ARDTOPICINFODTO_TYPE_TOKEN =
+          new TypeToken<ArdTopicInfoDto>() {
+          }.getType();
+  private static final String PAGE_NUMBER = "pageNumber";
+  private static final String URL_PAGE_NUMBER_REPLACE_REGEX = PAGE_NUMBER + "%22%3A\\d+";
+  private static final String PAGE_NUMBER_URL_ENCODED = PAGE_NUMBER + "%22%3A";
 
   public ArdTopicPageTask(MediathekReader aCrawler,
-          ConcurrentLinkedQueue<CrawlerUrlDTO> aUrlToCrawlDtos) {
+                          ConcurrentLinkedQueue<CrawlerUrlDTO> aUrlToCrawlDtos) {
     super(aCrawler, aUrlToCrawlDtos);
 
-    registerJsonDeserializer(SET_FILMINFO_TYPE_TOKEN, new ArdTopicPageDeserializer());
+    registerJsonDeserializer(ARDTOPICINFODTO_TYPE_TOKEN, new ArdTopicPageDeserializer());
   }
 
   @Override
@@ -30,11 +40,69 @@ public class ArdTopicPageTask extends ArdTaskBase<ArdFilmInfoDto, CrawlerUrlDTO>
       return;
     }
 
-    Set<ArdFilmInfoDto> filmUrls = deserialize(aTarget, SET_FILMINFO_TYPE_TOKEN);
+    final ArdTopicInfoDto topicInfo = deserialize(aTarget, ARDTOPICINFODTO_TYPE_TOKEN);
+    if (topicInfo != null
+            && topicInfo.getFilmInfos() != null
+            && !topicInfo.getFilmInfos().isEmpty()) {
+      taskResults.addAll(topicInfo.getFilmInfos());
+      LOG.debug("Found {} shows for a topic of ARD.", topicInfo.getFilmInfos().size());
 
-    if (filmUrls != null && !filmUrls.isEmpty()) {
-      taskResults.addAll(filmUrls);
+      final ConcurrentLinkedQueue<CrawlerUrlDTO> subpages = createSubPageUrls(aTarget, topicInfo);
+      if (!subpages.isEmpty()) {
+        taskResults.addAll(createNewOwnInstance(subpages).fork().join());
+      }
     }
+  }
+
+  private ConcurrentLinkedQueue<CrawlerUrlDTO> createSubPageUrls(
+          final WebTarget aTarget, final ArdTopicInfoDto topicInfo) {
+    final ConcurrentLinkedQueue<CrawlerUrlDTO> subpages = new ConcurrentLinkedQueue<>();
+
+    final int actualSubPageNumber = topicInfo.getSubPageNumber();
+    final int maximumAllowedSubpages = getMaximumSubpages();
+    if (actualSubPageNumber != 0) {
+      LOG.debug("Sub page {} is already the maximum allowed sub page.", actualSubPageNumber);
+      return subpages;
+    }
+
+    final int maxSubPageNumber = topicInfo.getMaxSubPageNumber();
+    subpages.addAll(
+            IntStream.range(
+                            actualSubPageNumber + 1,
+                            Math.min(maximumAllowedSubpages, maxSubPageNumber) + 1)
+                    .parallel()
+                    .mapToObj(subpageNumber -> changePageNumber(aTarget, subpageNumber))
+                    .map(CrawlerUrlDTO::new)
+                    .collect(Collectors.toSet()));
+
+    if (LOG.isDebugEnabled() && maxSubPageNumber > maximumAllowedSubpages) {
+      LOG.debug(
+              "Found {} sub pages, these are {} more then the allowed {} to crawl. Added {} and skipped the rest.",
+              maxSubPageNumber,
+              maxSubPageNumber - maximumAllowedSubpages,
+              maximumAllowedSubpages,
+              subpages.size());
+    }
+    return subpages;
+  }
+
+  private int getMaximumSubpages() {
+    return 0;
+  }
+
+  private String changePageNumber(final WebTarget aTarget, final int newPageNumber) {
+    return aTarget.getUri().toString().contains(PAGE_NUMBER)
+            ? aTarget
+            .getUriBuilder()
+            .replaceQuery(
+                    aTarget
+                            .getUri()
+                            .getRawQuery()
+                            .replaceAll(
+                                    URL_PAGE_NUMBER_REPLACE_REGEX, PAGE_NUMBER_URL_ENCODED + newPageNumber))
+            .build()
+            .toString()
+            : aTarget.queryParam(PAGE_NUMBER, newPageNumber).getUri().toString();
   }
 
   @Override


### PR DESCRIPTION
fix für [Forumseintrag](https://forum.mediathekview.de/topic/4638/fehlende-sendung-kinderlandverschickung)

eine manuelle Lösung, aber damit lassen sich alle Unterseiten eines ARD-Themas temporär lesen

die Laufzeit des Crawlers wird nicht groß beeinflusst.

Wenn der Nachtlauf erfolgreich war, werde ich die Liste der Topics wieder leeren.