### PR TITLE
Update player id from ngplayer_2_3 to ngplayer_2_4

### DIFF
--- a/src/main/java/mServer/crawler/sender/zdf/json/ZdfFilmDetailDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/zdf/json/ZdfFilmDetailDeserializer.java
@@ -41,7 +41,7 @@ public class ZdfFilmDetailDeserializer implements JsonDeserializer<Optional<ZdfF
   private static final String JSON_ATTRIBUTE_TEMPLATE = "http://zdf.de/rels/streams/ptmd-template";
 
   private static final String PLACEHOLDER_PLAYER_ID = "{playerId}";
-  private static final String PLAYER_ID = "ngplayer_2_3";
+  private static final String PLAYER_ID = "ngplayer_2_4";
 
   private static final String DOWNLOAD_URL_DEFAULT = "default";
   private static final String DOWNLOAD_URL_DGS = "dgs";


### PR DESCRIPTION
The new player version now also returns webm in the formats response.
Besides that everything should work as with ngplayer_2_3, so there should be no conflicts.