### PR TITLE
Remove unneeded parameter from videourl for SRF (develop)

### DIFF
--- a/src/main/java/de/mediathekview/mserver/base/utils/UrlUtils.java
+++ b/src/main/java/de/mediathekview/mserver/base/utils/UrlUtils.java
@@ -237,27 +237,30 @@ public final class UrlUtils {
     if (aUrl != null) {
       final Map<String, String> parameters = getUrlParameters(aUrl);
       if (parameters.containsKey(aParameterName)) {
-        return Optional.of(parameters.get(aParameterName));
+          return Optional.of(parameters.get(aParameterName));
       }
     }
 
     return Optional.empty();
   }
-
+  
+  // parsen von urls mit den Formaten
+  // https://my.domain.com?key1=abc&key2=def
+  // https://my.domain.com?key1=abc&key2=
+  // https://my.domain.com?key1=abc&key2
+  // https://my.domain.com?key1=ab=c&key2=def
   private static Map<String, String> getUrlParameters(final String aUrl) throws UrlParseException {
     final Map<String, String> parameters = new HashMap<>();
-
     final int indexParameterStart = aUrl.indexOf('?');
     if (indexParameterStart > 0) {
       final String parameterPart = aUrl.substring(indexParameterStart + 1);
       final String[] parameterArray = parameterPart.split("&");
-
       for (final String parameter : parameterArray) {
-        final String[] parts = parameter.split("=");
-        if (parts.length == 2) {
-          parameters.put(parts[0], parts[1]);
+        int splitKeyValue = parameter.indexOf('=');
+        if (splitKeyValue > 0 && splitKeyValue != parameter.length() ) {
+          parameters.put(parameter.substring(0, splitKeyValue) , parameter.substring(splitKeyValue+1));  
         } else {
-          throw new UrlParseException("Invalid url paramters: " + aUrl);
+          parameters.put(parameter, "");
         }
       }
     }

--- a/src/main/java/de/mediathekview/mserver/crawler/srf/parser/SrfFilmJsonDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/srf/parser/SrfFilmJsonDeserializer.java
@@ -333,7 +333,7 @@ public class SrfFilmJsonDeserializer implements JsonDeserializer<Optional<Film>>
 
   private Map<Resolution, String> readUrls(final String aM3U8Url) {
     Map<Resolution, String> urls = new EnumMap<>(Resolution.class);
-    final String optimizedUrl = getOptimizedUrl(aM3U8Url);
+    final String optimizedUrl = UrlUtils.removeParameters(getOptimizedUrl(aM3U8Url));
     Optional<String> content;
 
     try {

--- a/src/test/java/de/mediathekview/mserver/crawler/srf/parser/SrfFilmJsonDeserializerTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/srf/parser/SrfFilmJsonDeserializerTest.java
@@ -138,7 +138,7 @@ public class SrfFilmJsonDeserializerTest extends SrfTaskTestBase {
           {
             "/srf/srf_film_page_with_optimize_m3u8url.json",
             "/srf/srf_film_page_with_optimize_m3u8url.m3u8",
-            "/i/vod/lena/2018/11/lena_20181114_114517_12440540_v_webcast_h264_,q40,q10,q20,q30,q50,q60,.mp4.csmil/master.m3u8?start=0.0&end=2549.76",
+            "/i/vod/lena/2018/11/lena_20181114_114517_12440540_v_webcast_h264_,q40,q10,q20,q30,q50,q60,.mp4.csmil/master.m3u8",
             "Lena – Liebe meines Lebens",
             "Kapitel 156",
             LocalDateTime.of(2018, 11, 14, 11, 45, 0),


### PR DESCRIPTION
Fix für sich ändernde parameter in der video url für develop.
Hier gab es allerding noch eine nötigen fix für getUrlParameters weil die Funktion mit den heutigen SRL Parametern nicht zurecht kommmt. Weiter details zu den urls in #904 