### PR TITLE
update configurationmanager to support configuration file name

### DIFF
--- a/MServer-Config.yaml
+++ b/MServer-Config.yaml
@@ -182,7 +182,7 @@ copySettings:
   # En- / disables FTP
   copyEnabled: false
 
-  # The paths where to safe the film list files.SrfTopicOverviewTask
+  # The paths where to safe the film list files.
   # WARNING: You can only set the path for film list formats you listed in "filmlistSaveFormats".
   # Required if enabled
   copyTargetFilePaths:

--- a/MServer-Config.yaml
+++ b/MServer-Config.yaml
@@ -22,6 +22,7 @@ senderIncluded:
   #- KIKA
   - DW
   #- BR
+  #- PHOENIX
 
 # If set the server will be awake after the crawler run and restarts the run after the given amount.
 #schedules:
@@ -52,7 +53,7 @@ filmlistSaveFormats:
 
 # The paths where which filmlist should be safed to.
 filmlistSavePaths:
-#  JSON: target/filmlists/filmliste.json
+  JSON: target/filmlists/filmliste.json
   OLD_JSON: target/filmlists/filmliste_old.json
 #  JSON_COMPRESSED_XZ: target/filmlists/filmliste.json.xz
 #  OLD_JSON_COMPRESSED_XZ: target/filmlists/filmliste_old.json.xz
@@ -64,8 +65,8 @@ filmlistSavePaths:
 # The paths where which diff film list should be safed to.
 # If not set no difference film lists will be safed.
 filmlistDiffSavePaths:
-#  JSON: target/filmlists/filmliste_diff.json
-#  OLD_JSON: target/filmlists/filmliste_old_diff.json
+  JSON: target/filmlists/filmliste_diff.json
+  OLD_JSON: target/filmlists/filmliste_old_diff.json
 #  JSON_COMPRESSED_XZ: target/filmlists/filmliste_diff.json.xz
 #  OLD_JSON_COMPRESSED_XZ: target/filmlists/filmliste_old_diff.json.xz
 #  JSON_COMPRESSED_GZIP: target/filmlists/filmliste_diff.json.gz
@@ -76,12 +77,12 @@ filmlistDiffSavePaths:
 #Sets if a filmlist hash file should be written
 writeFilmlistHashFileEnabled: true
 #The filmlist hash file path
-filmlistHashFilePath: target/filmlists/filmlist.hash
+filmlistHashFilePath: target/filmlists/filmlist.hash.xx
 
 #Sets if a filmlist id file should be written
 writeFilmlistIdFileEnabled: true
 #The fimlist id file path
-filmlistIdFilePath: target/filmlists/filmlist.id
+filmlistIdFilePath: target/filmlists/filmlist.id.xx
 
 
 # import additional filmlist sources

--- a/src/main/java/de/mediathekview/mserver/base/config/Log4JConfigurationFactory.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/Log4JConfigurationFactory.java
@@ -45,9 +45,19 @@ public class Log4JConfigurationFactory extends ConfigurationFactory {
 
   private static MServerLogSettingsDTO logSettings;
 
+  public Log4JConfigurationFactory(MServerLogSettingsDTO logSettings) {
+    Log4JConfigurationFactory.logSettings = logSettings;
+  }
+  
+  
+  public Log4JConfigurationFactory() {
+    if (Log4JConfigurationFactory.logSettings == null) {
+      Log4JConfigurationFactory.logSettings = new MServerConfigManager(MServerConfigManager.DEFAULT_CONFIG_FILE).getConfig().getLogSettings();
+    }
+  }
+  
   static Configuration createConfiguration(
       final String name, final ConfigurationBuilder<BuiltConfiguration> aBuilder) {
-    logSettings = new MServerConfigManager().getConfig().getLogSettings();
 
     aBuilder.setConfigurationName(name);
 

--- a/src/main/java/de/mediathekview/mserver/base/config/MServerConfigDTO.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/MServerConfigDTO.java
@@ -15,7 +15,7 @@ public class MServerConfigDTO extends MServerBasicConfigDTO implements ConfigDTO
   private final Boolean writeFilmlistIdFileEnabled;
   private final String filmlistIdFilePath;
   /** ignore certain film by title **/
-  private final String ignoreFilmlistPath;
+  private String ignoreFilmlistPath;
   /** add livestreams from external list **/
   private final ImportLivestreamConfiguration importLivestreamConfiguration;
   /** add additional filmlist from external **/
@@ -146,6 +146,10 @@ public class MServerConfigDTO extends MServerBasicConfigDTO implements ConfigDTO
 
   public void setFilmlistSavePaths(final Map<FilmlistFormats, String> filmlistSavePaths) {
     this.filmlistSavePaths = filmlistSavePaths;
+  }
+  
+  public void setIgnoreFilmlistPath(final String ignoreFilmlistPath) {
+    this.ignoreFilmlistPath = ignoreFilmlistPath;
   }
 
   public MServerLogSettingsDTO getLogSettings() {

--- a/src/main/java/de/mediathekview/mserver/base/config/MServerConfigManager.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/MServerConfigManager.java
@@ -14,10 +14,6 @@ public class MServerConfigManager extends ConfigManager<MServerConfigDTO> {
     configFileName = fileName;
   }
 
-  public MServerConfigManager() {
-    this(DEFAULT_CONFIG_FILE);
-  }
-
   /**
    * @param aSender The {@link Sender} for which the config will be loaded.
    * @return The Sender specific config.

--- a/src/main/java/de/mediathekview/mserver/crawler/CrawlerManager.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/CrawlerManager.java
@@ -192,7 +192,13 @@ public class CrawlerManager extends AbstractManager {
       }
       //
       if (importFilmlistConfiguration.isCheckImportListUrl() && importedFilmlist.isPresent() ) {
-        importedFilmlist = Optional.of(new CheckUrlAvailability(config.getCheckImportListUrlMinSize() ,config.getCheckImportListUrlTimeoutInSec()).getAvaiableFilmlist(importedFilmlist.get()));
+        importedFilmlist = Optional.of(
+            new CheckUrlAvailability(
+                config.getCheckImportListUrlMinSize(),
+                config.getCheckImportListUrlTimeoutInSec(),
+                config.getMaximumCpuThreads())
+            .getAvaiableFilmlist(importedFilmlist.get())
+        );
       }
       //
       final Filmlist difflist = new Filmlist(UUID.randomUUID(), LocalDateTime.now());

--- a/src/main/java/de/mediathekview/mserver/crawler/CrawlerManager.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/CrawlerManager.java
@@ -57,8 +57,8 @@ public class CrawlerManager extends AbstractManager {
   private static final String FILMLIST_JSON_COMPRESSED_DEFAULT_NAME =
       FILMLIST_JSON_DEFAULT_NAME + ".xz";
   private static final Logger LOG = LogManager.getLogger(CrawlerManager.class);
-  private static CrawlerManager instance;
   private final MServerConfigDTO config;
+  private final MServerConfigManager rootConfig;
   private final ForkJoinPool forkJoinPool;
   private final Filmlist filmlist;
   private final IgnoreFilmFilter ingoreFilmFilter;
@@ -70,9 +70,9 @@ public class CrawlerManager extends AbstractManager {
   private final Collection<ProgressListener> copyProgressListeners;
   private final Filmlist differenceList;
 
-  private CrawlerManager() {
+  public CrawlerManager(MServerConfigManager aMServerConfigManager) {
     super();
-    final MServerConfigManager rootConfig = new MServerConfigManager();
+    rootConfig = aMServerConfigManager;
     config = rootConfig.getConfig();
     ingoreFilmFilter = new IgnoreFilmFilter(config.getIgnoreFilmslistPath());
     executorService = Executors.newFixedThreadPool(config.getMaximumCpuThreads());
@@ -86,11 +86,8 @@ public class CrawlerManager extends AbstractManager {
     initializeCrawler(rootConfig);
   }
 
-  public static CrawlerManager getInstance() {
-    if (instance == null) {
-      instance = new CrawlerManager();
-    }
-    return instance;
+  public MServerConfigManager getConfigManager() {
+    return rootConfig;
   }
 
   public void copyFilmlist() {
@@ -166,6 +163,7 @@ public class CrawlerManager extends AbstractManager {
   }
   
   public void importLivestreamFilmlist(final FilmlistFormats aFormat, final String aFilmlistLocation) {
+    LOG.debug("importLivestreamFilmlist {}", aFilmlistLocation);
     try {
       final Optional<Filmlist> importedFilmlist;
       if (aFilmlistLocation.startsWith(HTTP)) {

--- a/src/main/java/de/mediathekview/mserver/crawler/basic/IgnoreFilmFilter.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/basic/IgnoreFilmFilter.java
@@ -31,7 +31,7 @@ public class IgnoreFilmFilter {
       } else {
         ignoreFilmTitles = read(configFileNameAndPath);
       }
-      LOG.debug("ignoreFilmList setup with {} entries", size());
+      LOG.debug("ignoreFilmList {} setup with {} entries", configFileNameAndPath, size());
     } catch (IOException e) {
       LOG.error("Could not read ignorefilmlist from {} ",configFileNameAndPath, e);
     }

--- a/src/main/java/de/mediathekview/mserver/crawler/funk/json/FunkVideoDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/funk/json/FunkVideoDeserializer.java
@@ -73,9 +73,7 @@ public class FunkVideoDeserializer extends AbstractFunkElementDeserializer<FilmI
   }
 
   private MServerConfigDTO getRuntimeConfig() {
-    return crawler
-        .map(AbstractCrawler::getRuntimeConfig)
-        .orElseGet(() -> new MServerConfigManager().getConfig());
+    return crawler.get().getRuntimeConfig();
   }
 
   private String createNexxCloudUrl(final String entityId) {

--- a/src/main/java/de/mediathekview/mserver/crawler/sr/tasks/SrFilmDetailTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/sr/tasks/SrFilmDetailTask.java
@@ -18,7 +18,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
 import org.jsoup.select.Elements;
 
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/de/mediathekview/mserver/crawler/sr/tasks/SrRateLimitedDocumentTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/sr/tasks/SrRateLimitedDocumentTask.java
@@ -14,9 +14,7 @@ public abstract class SrRateLimitedDocumentTask<T, D extends CrawlerUrlDTO>
 
   private static final long serialVersionUID = -4077182368484515410L;
 
-  private static final RateLimiter LIMITER =
-      RateLimiter.create(
-          new MServerConfigManager().getSenderConfig(Sender.SR).getMaximumRequestsPerSecond());
+  private static RateLimiter LIMITER = null;
 
   SrRateLimitedDocumentTask(
       final AbstractCrawler crawler,
@@ -26,6 +24,9 @@ public abstract class SrRateLimitedDocumentTask<T, D extends CrawlerUrlDTO>
 
   @Override
   protected void processElement(final D urlDTO) {
+    if (LIMITER== null) {
+      LIMITER = RateLimiter.create(crawler.getRuntimeConfig().getSenderConfig(Sender.SR).getMaximumRequestsPerSecond());
+    }
     LIMITER.acquire();
     super.processElement(urlDTO);
   }

--- a/src/main/resources/MServer-Config.yaml
+++ b/src/main/resources/MServer-Config.yaml
@@ -7,6 +7,9 @@ maximumCpuThreads: 16
 # If set to 0 the server runs without a time limit.
 maximumServerDurationInMinutes: 0
 
+# Rate limiter
+maximumRequestsPerSecond: 999.0
+
 # These Sender will NOT be crawled.
 # If no Sender are included the server will crawl all Sender but these.
 #senderExcluded:
@@ -77,22 +80,40 @@ writeFilmlistIdFileEnabled: true
 #The fimlist id file path
 filmlistIdFilePath: target/filmlist.id
 
-# Sets if a filmlist should be imported
-filmlistImporEnabled: false
+# import additional filmlist sources
+importFilmlistConfigurations :
+    - active: false
+      path: "someCrawlerlist.json"
+      format: OLD_JSON
+      createDiff: false
+      checkImportListUrl: false
+    - active: false
+      path: "someMoreCrawlerlist.json"
+      format: OLD_JSON
+      createDiff: false
+      checkImportListUrl: false
+    - active: false
+      path: "https://verteiler1.mediathekview.de/filme-org.xz"
+      format: OLD_JSON_COMPRESSED_XZ
+      createDiff: true
+      checkImportListUrl: true    
 
-# The format of the film list to import.
-# Possible are: JSON, OLD_JSON, JSON_COMPRESSED_XZ, OLD_JSON_COMPRESSED_XZ, JSON_COMPRESSED_GZIP, OLD_JSON_COMPRESSED_BZIP, JSON_COMPRESSED_GZIP, OLD_JSON_COMPRESSED_BZIP
-#filmlistImportFormat: OLD_JSON_COMPRESSED_XZ
+# film url is consider invalid if the size is below the minSize
+checkImportListUrlMinSize: 5012
 
-# The path/URL of the film list to import.
-#filmlistImportLocation: http://verteiler1.mediathekview.de/Filmliste-akt.xz
+# abort url checking after x sec
+checkImportListUrlTimeoutInSec: 1800
 
 #### Default crawler configurations ####
 # The maximum amount of URLs to be processed per task.
 maximumUrlsPerTask: 50
 
 # The maximum duration in minutes a crawler may run.
-maximumCrawlDurationInMinutes: 60
+maximumCrawlDurationInMinutes: 120
+
+# Enables the topics search
+# maximumSubpages limits the depth of the topics search
+topicsSearchEnabled: false
 
 # The maximum amount of sub pages to be crawled.<br>
 # Example: If a Sendung overview side has 10 pages with videos for this Sendung and
@@ -113,9 +134,20 @@ socketTimeoutInSeconds: 60
 senderConfigurations:
   ARD:
     # Actually the ARD has a maximum of 6 days in the past
-    maximumDaysForSendungVerpasstSection: 6
+    maximumDaysForSendungVerpasstSection: 1
+    #2,4,8 ok
+    maximumUrlsPerTask: 32
+    #10,20,40 ok
+    maximumSubpages: 0
+  ORF:
+    #2,4,8 ok
+    maximumUrlsPerTask: 40
   ARTE_DE:
-    maximumDaysForSendungVerpasstSectionFuture: 21
+    maximumUrlsPerTask: 1
+    maximumDaysForSendungVerpasstSectionFuture: 0
+    maximumRequestsPerSecond: 2.0
+  ARTE_FR:
+    maximumDaysForSendungVerpasstSectionFuture: 0
     # The maximum amount of URLs to be processed per task.
     #        maximumUrlsPerTask: 25
     # The maximum duration in minutes a crawler may run.
@@ -125,9 +157,21 @@ senderConfigurations:
     # the amount set by this is 5 then the crawler crawls pages 1 to 5.
   #          maximumSubpages: 3
   KIKA:
-    socketTimeoutInSeconds: 120
+    maximumSubpages: 2
+    maximumRequestsPerSecond: 8.0
+  SR:
+    maximumRequestsPerSecond: 2.0
+  ZDF:
+    maximumRequestsPerSecond: 10.0
+  FUNK:
+    maximumUrlsPerTask: 99
+  DW:
+    maximumSubpages: 0
 
-
+# configure string variables
+crawlerApiParams:
+  FUNK_REQUEST_TOKEN: 137782e774d7cadc93dcbffbbde0ce9c
+  
 #### COPY ####
 copySettings:
   # En- / disables FTP

--- a/src/test/java/de/mediathekview/mserver/crawler/CrawlerManagerImportFilmlistsTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/CrawlerManagerImportFilmlistsTest.java
@@ -6,6 +6,7 @@ import de.mediathekview.mlib.messages.MessageTypes;
 import de.mediathekview.mlib.messages.MessageUtil;
 import de.mediathekview.mlib.messages.listener.MessageListener;
 import de.mediathekview.mserver.base.config.ImportFilmlistConfiguration;
+import de.mediathekview.mserver.base.config.MServerConfigManager;
 import de.mediathekview.mserver.testhelper.FileReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 
 public class CrawlerManagerImportFilmlistsTest implements MessageListener {
 
-  private static final Logger LOG = LogManager.getLogger(CrawlerManagerImportFilmlistsTest.class);
+  private Logger LOG;
   private static final String TEMP_FOLDER_NAME_PATTERN = "MSERVER_TEST_%d";
   private static Path testFileFolderPath;
 
@@ -87,16 +87,9 @@ public class CrawlerManagerImportFilmlistsTest implements MessageListener {
   }
 
   public CrawlerManager createEmptyCrawlerManager() {
-    // reset singelton CrawlerManager to have an empty filmlist
-    Field instance;
-    try {
-      instance = CrawlerManager.class.getDeclaredField("instance");
-      instance.setAccessible(true);
-      instance.set(null, null);
-    } catch (Exception e) {
-      fail("Exception mooking crawler manager: " + e.getMessage());
-    }    //
-    return CrawlerManager.getInstance();
+    CrawlerManager cm = new CrawlerManager(new MServerConfigManager(MServerConfigManager.DEFAULT_CONFIG_FILE));
+    LOG = LogManager.getLogger(CrawlerManagerImportFilmlistsTest.class);
+    return cm;
   }
 
   @AfterAll

--- a/src/test/java/de/mediathekview/mserver/crawler/CrawlerManagerLivestreamTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/CrawlerManagerLivestreamTest.java
@@ -6,6 +6,7 @@ import de.mediathekview.mlib.messages.MessageTypes;
 import de.mediathekview.mlib.messages.MessageUtil;
 import de.mediathekview.mlib.messages.listener.MessageListener;
 import de.mediathekview.mserver.base.config.ImportFilmlistConfiguration;
+import de.mediathekview.mserver.base.config.MServerConfigManager;
 import de.mediathekview.mserver.testhelper.FileReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -74,16 +74,7 @@ public class CrawlerManagerLivestreamTest implements MessageListener {
   }
 
   public CrawlerManager createEmptyCrawlerManager() {
-    // reset singelton CrawlerManager to have an empty filmlist
-    Field instance;
-    try {
-      instance = CrawlerManager.class.getDeclaredField("instance");
-      instance.setAccessible(true);
-      instance.set(null, null);
-    } catch (Exception e) {
-      fail("Exception mooking crawler manager: " + e.getMessage());
-    }    //
-    return CrawlerManager.getInstance();
+    return new CrawlerManager(new MServerConfigManager(MServerConfigManager.DEFAULT_CONFIG_FILE));
   }
 
   @AfterAll

--- a/src/test/java/de/mediathekview/mserver/crawler/CrawlerManagerTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/CrawlerManagerTest.java
@@ -6,6 +6,7 @@ import de.mediathekview.mlib.messages.MessageTypes;
 import de.mediathekview.mlib.messages.MessageUtil;
 import de.mediathekview.mlib.messages.listener.MessageListener;
 import de.mediathekview.mserver.base.config.ImportFilmlistConfiguration;
+import de.mediathekview.mserver.base.config.MServerConfigManager;
 import de.mediathekview.mserver.testhelper.FileReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,7 +19,6 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -27,12 +27,11 @@ import java.util.Comparator;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public class CrawlerManagerTest implements MessageListener {
 
-  private static final Logger LOG = LogManager.getLogger(CrawlerManagerTest.class);
+  private Logger LOG;
   private static final String TEMP_FOLDER_NAME_PATTERN = "MSERVER_TEST_%d";
   private static Path testFileFolderPath;
 
@@ -45,16 +44,8 @@ public class CrawlerManagerTest implements MessageListener {
     filmlistPath = aFilmlistPath;
     expectedSize = aExpectedSize;
     format = aFormat;
-    // reset singelton CrawlerManager
-    Field instance;
-    try {
-      instance = CrawlerManager.class.getDeclaredField("instance");
-      instance.setAccessible(true);
-      instance.set(null, null);
-    } catch (Exception e) {
-      fail("Exception mooking crawler manager: " + e.getMessage());
-    }    //
-    CRAWLER_MANAGER = CrawlerManager.getInstance();
+    CRAWLER_MANAGER = new CrawlerManager(new MServerConfigManager(MServerConfigManager.DEFAULT_CONFIG_FILE));
+    LOG = LogManager.getLogger(CrawlerManagerTest.class);
   }
 
   @Parameterized.Parameters(name = "Test {index} Filmlist for {0} with {1}")

--- a/src/test/java/de/mediathekview/mserver/crawler/ard/json/ArdTopicPageDeserializerTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/ard/json/ArdTopicPageDeserializerTest.java
@@ -7,10 +7,8 @@ import de.mediathekview.mserver.testhelper.JsonFileReader;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.net.URLEncoder;
 import java.util.Set;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/src/test/java/de/mediathekview/mserver/crawler/zdf/parser/ZdfTopicsPageHtmlDeserializerTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/zdf/parser/ZdfTopicsPageHtmlDeserializerTest.java
@@ -1,7 +1,6 @@
 package de.mediathekview.mserver.crawler.zdf.parser;
 
 import de.mediathekview.mserver.crawler.basic.CrawlerUrlDTO;
-import de.mediathekview.mserver.crawler.zdf.ZdfConstants;
 import de.mediathekview.mserver.testhelper.FileReader;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;


### PR DESCRIPTION
Remove static cralwermanager - was only used in test cases
Pin config in log4jfactory
Avoid building new config instance in some cases
Remove workaround for static crawlermanager in test cases
Restructure main to allow passing configfile to configurationmanager
update test cases and remove some unused imports