### PR TITLE
add date to title for regular topics

### DIFF
--- a/src/main/java/de/mediathekview/mserver/crawler/dw/DwConstants.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/dw/DwConstants.java
@@ -1,10 +1,15 @@
 package de.mediathekview.mserver.crawler.dw;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class DwConstants {
   private DwConstants() {}
   
   public static final String URL_BASE = "https://api.dw.com/api";
 
   public static final String URL_OVERVIEW = "/list/mediacenter/1?pageIndex=1";
+  
+  public static final List<String> REGULAR_TOPICS = Arrays.asList("Euromaxx", "Shift", "Fokus Europa", "Projekt Zukunft", "Global Us");
   
 }

--- a/src/main/java/de/mediathekview/mserver/crawler/dw/parser/DwFilmDetailDeserializer.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/dw/parser/DwFilmDetailDeserializer.java
@@ -7,6 +7,7 @@ import de.mediathekview.mlib.daten.Resolution;
 import de.mediathekview.mlib.daten.Sender;
 import de.mediathekview.mserver.base.utils.JsonUtils;
 import de.mediathekview.mserver.crawler.basic.AbstractCrawler;
+import de.mediathekview.mserver.crawler.dw.DwConstants;
 import de.mediathekview.mserver.crawler.dw.DwVideoDto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,7 +128,10 @@ public class DwFilmDetailDeserializer implements JsonDeserializer<Optional<Film>
     final JsonArray jsonObjectMainContentSources =
         jsonObjectMainContent.get(ELEMENT_MAINCONTENT_SOURCES).getAsJsonArray();
     getVideos(title.get(), jsonObjectMainContentSources).ifPresent(film::addAllUrls);
-    //
+    // Euromaxx always has the same title and we do not get the subtitle
+    if (DwConstants.REGULAR_TOPICS.contains(film.getThema())) {
+      film.setTitel(film.getTitel() + " " + film.getTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));  
+    }
     return Optional.of(film);
   }
 

--- a/src/main/java/de/mediathekview/mserver/crawler/dw/tasks/DWOverviewTask.java
+++ b/src/main/java/de/mediathekview/mserver/crawler/dw/tasks/DWOverviewTask.java
@@ -15,7 +15,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class DWOverviewTask extends DWTaskBase<CrawlerUrlDTO, CrawlerUrlDTO> {
-
+  private static final long serialVersionUID = 4050423702709695861L;
   private static final Type OPTIONAL_OVERVIEW_DTO_TYPE_TOKEN =
       new TypeToken<Optional<PagedElementListDTO<CrawlerUrlDTO>>>() {}.getType();
   private final int subpage;

--- a/src/test/java/de/mediathekview/mserver/crawler/dw/tasks/DWDetailDeserializerTest.java
+++ b/src/test/java/de/mediathekview/mserver/crawler/dw/tasks/DWDetailDeserializerTest.java
@@ -95,7 +95,7 @@ public class DWDetailDeserializerTest extends DwTaskTestBase {
           },
           {
             "/dw/dw_film_detail_five_video_urls.json",
-            "Energiezukunft? Schwimmende Windkraftanlagen",
+            "Energiezukunft? Schwimmende Windkraftanlagen 2022-11-12",
             "Projekt Zukunft",
             "https://p.dw.com/p/4JNwb",
             Duration.ofSeconds(385),


### PR DESCRIPTION
Bei z.B. "Euromaxx - Leben und Kultur in Europa" ist auf der Mediathek ein Untertitel vorhanden (z.B. Spanien). In der API gibt es diesen nicht. Der neuen Crawler nimmt die Sendungen dann nicht mehr in die Liste auf (duplikat).