### PR TITLE
temporary fix for old zdf mediathek

### DIFF
--- a/src/main/java/mServer/crawler/sender/zdf/ZdfConfiguration.java
+++ b/src/main/java/mServer/crawler/sender/zdf/ZdfConfiguration.java
@@ -8,8 +8,8 @@ public class ZdfConfiguration {
   private Optional<String> videoAuthKey;
 
   public ZdfConfiguration() {
-    searchAuthKey = Optional.empty();
-    videoAuthKey = Optional.empty();
+    searchAuthKey = Optional.of("5bb200097db507149612d7d983131d06c79706d5");
+    videoAuthKey = Optional.of("20c238b5345eb428d01ae5c748c5076f033dfcc7");
   }
 
   public Optional<String> getSearchAuthKey() {


### PR DESCRIPTION
#1039 

@alex1702 ein Hack, mit dem der alte ZDF-Crawler noch läuft, damit ich mehr Zeit für die Umstellung auf die neue Mediathek habe.