### PR TITLE
Tagesschau vor 20 Jahren

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ java -jar MServer.jar
 
 # Überblick der Crawler
 
-| Crawler | liest Mediathek | beinhaltet Sender                                                                            | bestückt Sender | entspricht Develop |
-|---------|-----------|----------------------------------------------------------------------------------------------|---------|--|
-| 3sat|3sat-Mediathek| 3sat                                                                                         |3sat|x|
-| ARD|ARD-Mediathek| Alpha, BR, Das Erste, FUNK, HR, MDR, NDR, ONE, Radio Bremen, RBB, SR, SWR, WDR, tagesschau24 |ARD, BR, HR, MDR, NDR, Radio Bremen, RBB, SWR, WDR| x|
-| ARTE|ARTE-Mediathek| ARTE in DE, FR, EN, ES, PL, IT                                                               |ARTE.DE, ARTE.FR||
-| DW|DW-Mediathek| DW                                                                                           |DW|x|
-| KIKA|KIKA-Mediathek| KIKA                                                                                         |KIKA|x|
-| ORF|ORF-Mediathek| ORF1, ORF2, ORF3, ORFSport                                                                   |ORF|x|
-| PHOENIX|PHOENIX-Mediathek| PHOENIX                                                                                      |PHOENIX|x|
-| SR|SR-Mediathek| SR                                                                                           |SR|x|
-| SRF|SRF-Mediathek| SRF1, SRF2, SRFinfo                                                                          |SRF|x|
-| ZDF|ZDF-Mediathek| ZDF, ZDFneo, ZDFinfo                                                                         |ZDF|x|
+| Crawler | liest Mediathek         | beinhaltet Sender                                                                            | bestückt Sender                                    | entspricht Develop |
+|---------|-------------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------|--|
+| 3sat| 3sat-Mediathek          | 3sat                                                                                         | 3sat                                               |x|
+| ARD| ARD-Mediathek           | Alpha, BR, Das Erste, FUNK, HR, MDR, NDR, ONE, Radio Bremen, RBB, SR, SWR, WDR, tagesschau24 | ARD, BR, HR, MDR, NDR, Radio Bremen, RBB, SWR, WDR | x|
+| ARTE| ARTE-Mediathek          | ARTE in DE, FR, EN, ES, PL, IT                                                               | ARTE.DE, ARTE.FR                                   ||
+| DW| DW-Mediathek            | DW                                                                                           | DW                                                 |x|
+| KIKA| KIKA-Mediathek          | KIKA                                                                                         | KIKA                                               |x|
+| ORF| ORF-Mediathek           | ORF1, ORF2, ORF3, ORFSport                                                                   | ORF                                                |x|
+| PHOENIX| PHOENIX-Mediathek       | PHOENIX                                                                                      | PHOENIX                                            |x|
+| SR| SR-Mediathek            | SR                                                                                           | SR                                                 |x|
+| SRF| SRF-Mediathek           | SRF1, SRF2, SRFinfo                                                                          | SRF                                                |x|
+| Tagesschau | tagesschau.de | Tagesschau vor 20 Jahren                                                                     | tagesschau24                                       |x |
+| ZDF| ZDF-Mediathek           | ZDF, ZDFneo, ZDFinfo                                                                         | ZDF                                                |x|

--- a/src/main/java/mServer/crawler/FilmeSuchen.java
+++ b/src/main/java/mServer/crawler/FilmeSuchen.java
@@ -35,6 +35,7 @@ import mServer.crawler.sender.orfon.OrfOnCrawler;
 import mServer.crawler.sender.phoenix.PhoenixCrawler;
 import mServer.crawler.sender.sr.SrCrawler;
 import mServer.crawler.sender.srf.SrfCrawler;
+import mServer.crawler.sender.tagesschau.TagesschauCrawler;
 import mServer.crawler.sender.zdf.ZdfCrawler;
 import mServer.tool.MserverDaten;
 import mServer.tool.MserverKonstanten;
@@ -118,6 +119,9 @@ public class FilmeSuchen {
     }
     if (crawlerList.contains("PHONIX")) {
       mediathekListe.add(new PhoenixCrawler(this, 0));
+    }
+    if (crawlerList.contains("TAGESSCHAU")) {
+      mediathekListe.add(new TagesschauCrawler(this, 1));
     }
   
   }

--- a/src/main/java/mServer/crawler/sender/tagesschau/EntryUrlDto.java
+++ b/src/main/java/mServer/crawler/sender/tagesschau/EntryUrlDto.java
@@ -1,0 +1,32 @@
+package mServer.crawler.sender.tagesschau;
+
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class EntryUrlDto {
+  private final Set<CrawlerUrlDTO> videos;
+  private final Set<CrawlerUrlDTO> subPages;
+
+  public EntryUrlDto() {
+    this.videos = new HashSet<>();
+    this.subPages = new HashSet<>();
+  }
+
+  public Set<CrawlerUrlDTO> getVideos() {
+    return videos;
+  }
+
+  public Set<CrawlerUrlDTO> getSubPages() {
+    return subPages;
+  }
+
+  public void addVideo(CrawlerUrlDTO videoUrl) {
+    this.videos.add(videoUrl);
+  }
+
+  public void addSubPage(CrawlerUrlDTO subPageUrl) {
+    this.subPages.add(subPageUrl);
+  }
+}

--- a/src/main/java/mServer/crawler/sender/tagesschau/TagesschauConstants.java
+++ b/src/main/java/mServer/crawler/sender/tagesschau/TagesschauConstants.java
@@ -1,0 +1,18 @@
+package mServer.crawler.sender.tagesschau;
+
+/**
+ * Constants for the Tagesschau crawler.
+ * Handles the "vor 20 Jahren" (20 years ago) archive with daily news broadcasts.
+ */
+public final class TagesschauConstants {
+
+  // Starting point: Tagesschau vor 20 Jahren (20 years ago)
+  public static final String ARCHIVE_START_URL = "https://www.tagesschau.de/inland/tsvorzwanzigjahren-ts-142.html";
+
+  // Private constructor to hide the implicit public one
+  private TagesschauConstants() {
+    // Utility class, do not instantiate
+  }
+}
+
+

--- a/src/main/java/mServer/crawler/sender/tagesschau/TagesschauCrawler.java
+++ b/src/main/java/mServer/crawler/sender/tagesschau/TagesschauCrawler.java
@@ -1,0 +1,80 @@
+package mServer.crawler.sender.tagesschau;
+
+import de.mediathekview.mlib.Const;
+import de.mediathekview.mlib.daten.DatenFilm;
+import de.mediathekview.mlib.tool.Log;
+import mServer.crawler.CrawlerTool;
+import mServer.crawler.FilmeSuchen;
+import mServer.crawler.sender.MediathekCrawler;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.tagesschau.tasks.TagesschauEntriesTask;
+import mServer.crawler.sender.tagesschau.tasks.TagesschauVideoTask;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RecursiveTask;
+
+public class TagesschauCrawler extends MediathekCrawler {
+
+  private static final Logger LOG = LogManager.getLogger(TagesschauCrawler.class);
+
+  public TagesschauCrawler(FilmeSuchen ssearch, int startPrio) {
+    super(ssearch, Const.TAGESSCHAU24, 0, 1, startPrio);
+  }
+
+  @Override
+  protected RecursiveTask<Set<DatenFilm>> createCrawlerTask() {
+    try {
+      Set<CrawlerUrlDTO> videos = new HashSet<>();
+      ConcurrentLinkedQueue<CrawlerUrlDTO> inputQueue = createArchiveUrl();
+
+      // short run uses 2 recursion -> only the actual month is included
+      int recursionMax = CrawlerTool.loadLongMax() ? 10 : 2;
+      int recursionCount = 0;
+
+      while (!inputQueue.isEmpty() && recursionCount < recursionMax) {
+        LOG.debug("processing {} sub pages", inputQueue.size());
+        TagesschauEntriesTask round1 = new TagesschauEntriesTask(this, inputQueue);
+        final Set<EntryUrlDto> results = this.forkJoinPool.submit(round1).get();
+
+        Set<CrawlerUrlDTO> subPages = new HashSet<>();
+        results.forEach(
+                result -> {
+                  videos.addAll(result.getVideos());
+                  subPages.addAll(result.getSubPages());
+                });
+        inputQueue = new ConcurrentLinkedQueue<>(subPages);
+        recursionCount++;
+      }
+
+      Log.sysLog("Tagesschau 20 Jahre Anzahl topics: " + videos.size());
+      meldungAddMax(videos.size());
+
+      return new TagesschauVideoTask(this, new ConcurrentLinkedQueue<>(videos));
+
+    } catch (final InterruptedException ex) {
+      LOG.fatal("Exception in Tagesschau crawler.", ex);
+      Thread.currentThread().interrupt();
+    } catch (final ExecutionException ex) {
+      LOG.fatal("Exception in Tagesschau crawler.", ex);
+    }
+    return new RecursiveTask<>() {
+      @Override
+      protected Set<DatenFilm> compute() {
+        return Set.of();
+      }
+    };
+  }
+
+  private ConcurrentLinkedQueue<CrawlerUrlDTO> createArchiveUrl() {
+    ConcurrentLinkedQueue<CrawlerUrlDTO> urls = new ConcurrentLinkedQueue<>();
+    urls.add(new CrawlerUrlDTO(TagesschauConstants.ARCHIVE_START_URL));
+    return urls;
+  }
+}
+
+

--- a/src/main/java/mServer/crawler/sender/tagesschau/json/TagesschauVideoDeserializer.java
+++ b/src/main/java/mServer/crawler/sender/tagesschau/json/TagesschauVideoDeserializer.java
@@ -1,0 +1,190 @@
+package mServer.crawler.sender.tagesschau.json;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.lang.reflect.Type;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import de.mediathekview.mlib.Const;
+import de.mediathekview.mlib.daten.DatenFilm;
+import mServer.crawler.CrawlerTool;
+import mServer.crawler.sender.base.JsonUtils;
+import mServer.crawler.sender.base.Qualities;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TagesschauVideoDeserializer implements JsonDeserializer<List<DatenFilm>> {
+  private static final String ELEMENT_MC = "mc";
+  private static final String ELEMENT_MEDIA = "media";
+  private static final String ELEMENT_META = "meta";
+  private static final String ELEMENT_PLUG_IN_DATA = "pluginData";
+  private static final String ELEMENT_SHARING_WEB = "sharing@web";
+  private static final String ELEMENT_STREAMS = "streams";
+
+  private static final String ATTRIBUTE_DATE = "broadcastedOnDateTime";
+  private static final String ATTRIBUTE_DURATION = "durationSeconds";
+  private static final String ATTRIBUTE_TOPIC = "seriesTitle";
+  private static final String ATTRIBUTE_TITLE = "title";
+
+  private static final String ATTRIBUTE_WIDTH = "maxHResolutionPx";
+  private static final String ATTRIBUTE_MIMETYPE = "mimeType";
+  private static final String ATTRIBUTE_URL = "url";
+  private static final String ATTRIBUTE_LINK = "link";
+  private static final String[] SUPPORTED_MIME_TYPES = new String[] { "video/mp4" };
+
+  private static final DateTimeFormatter DATE_FORMAT
+          = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+  private static final DateTimeFormatter TIME_FORMAT
+          = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+  private static final Pattern LONG_MONTH_PATTERN =
+      Pattern.compile("(\\d{1,2}(?:\\.|\\s)\\s*[A-Za-zÄÖÜäöüß]+\\s+\\d{4})");
+  private static final DateTimeFormatter GERMAN_LONG = new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .appendPattern("d. MMMM uuuu")
+          .toFormatter(Locale.GERMAN);
+  private static final DateTimeFormatter GERMAN_LONG_NO_SPACE = new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .appendPattern("d.MMMM uuuu")
+          .toFormatter(Locale.GERMAN);
+  private static final DateTimeFormatter GERMAN_LONG_NO_DOT = new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .appendPattern("d MMMM uuuu")
+          .toFormatter(Locale.GERMAN);
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+          DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ", Locale.GERMANY);
+  private static final String GERMAN_TIME_ZONE = "Europe/Berlin";
+  private static final Logger LOG = LogManager.getLogger(TagesschauVideoDeserializer.class);
+
+  private static Optional<LocalDateTime> parseDate(final JsonObject metaObject, final Optional<LocalDate> titleDate) {
+    final Optional<String> dateValue =
+            JsonUtils.getAttributeAsString(metaObject, ATTRIBUTE_DATE);
+    if (dateValue.isPresent()) {
+      try {
+        final OffsetDateTime inputDateTime = OffsetDateTime.parse(dateValue.get(), DATE_TIME_FORMATTER);
+        LocalDateTime localDateTime = inputDateTime.atZoneSameInstant(ZoneId.of(GERMAN_TIME_ZONE)).toLocalDateTime();
+        if (titleDate.isPresent() && titleDate.get().getYear() != localDateTime.getYear()) {
+          localDateTime = localDateTime.withYear(titleDate.get().getYear());
+        }
+        return Optional.of(localDateTime);
+      } catch (final DateTimeParseException ex) {
+        LOG.warn("Error parsing date time value {}", dateValue.get(), ex);
+      }
+    }
+
+    return titleDate.map(localDate -> LocalDateTime.of(localDate, LocalTime.of(20, 0)));
+  }
+
+  @Override
+  public List<DatenFilm> deserialize(
+      JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) {
+
+    final List<DatenFilm> results = new ArrayList<>();
+
+    Optional<JsonElement> mcElement = JsonUtils.getElement(jsonElement, ELEMENT_MC);
+    if (mcElement.isPresent()) {
+      final Optional<JsonElement> metaElement = JsonUtils.getElement(mcElement.get(), ELEMENT_META);
+      if (metaElement.isPresent()) {
+        final JsonObject metaObject = metaElement.get().getAsJsonObject();
+        final Optional<String> topic = JsonUtils.getAttributeAsString(metaObject, ATTRIBUTE_TOPIC);
+        final Optional<String> title = JsonUtils.getAttributeAsString(metaObject, ATTRIBUTE_TITLE);
+        final Optional<Integer> duration = JsonUtils.getAttributeAsInt(metaObject, ATTRIBUTE_DURATION);
+        final LocalDateTime date = parseDate(metaObject, parseDateFromTitle(title.orElse(""))).orElse(LocalDateTime.now());
+        final Map<Qualities, String> urls = parseUrls(mcElement.get().getAsJsonObject());
+        final String website = parseWebsite(mcElement.get().getAsJsonObject());
+
+        String dateValue = date.format(DATE_FORMAT);
+        String timeValue = date.format(TIME_FORMAT);
+
+        DatenFilm film = new DatenFilm(Const.TAGESSCHAU24, topic.orElse(""), website, title.orElse(""), urls.get(Qualities.NORMAL), "",
+                dateValue, timeValue, duration.orElse(0), "");
+
+        if (urls.containsKey(Qualities.SMALL)) {
+          CrawlerTool.addUrlKlein(film, urls.get(Qualities.SMALL));
+        }
+        if (urls.containsKey(Qualities.HD)) {
+          CrawlerTool.addUrlHd(film, urls.get(Qualities.HD));
+        }
+
+        results.add(film);
+      }
+    }
+
+    return results;
+  }
+
+  private Optional<LocalDate> parseDateFromTitle(String title) {
+    Matcher m = LONG_MONTH_PATTERN.matcher(title);
+    if (m.find()) {
+      String datePart = m.group(1).replaceAll("\\s+", " ").trim();
+      try {
+        return Optional.of(LocalDate.parse(datePart, GERMAN_LONG));
+      } catch (DateTimeParseException ignored) {
+        // try other conversion
+      }
+      try {
+        return Optional.of(LocalDate.parse(datePart, GERMAN_LONG_NO_SPACE));
+      } catch (DateTimeParseException ignored) {
+        // try other conversion
+      }
+      try {
+        return Optional.of(LocalDate.parse(datePart, GERMAN_LONG_NO_DOT));
+      } catch (DateTimeParseException ex) {
+        LOG.debug("no valid date converted", ex);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private String parseWebsite(JsonObject mcObject) {
+    return JsonUtils.getElementValueAsString(mcObject, ELEMENT_PLUG_IN_DATA, ELEMENT_SHARING_WEB, ATTRIBUTE_LINK).orElse("");
+  }
+
+  private Map<Qualities, String> parseUrls(final JsonObject mcObject) {
+    final Map<Qualities, String> urls = new EnumMap<>(Qualities.class);
+    if (mcObject.has(ELEMENT_STREAMS) && mcObject.get(ELEMENT_STREAMS).isJsonArray()) {
+      mcObject
+          .get(ELEMENT_STREAMS)
+          .getAsJsonArray()
+          .forEach(
+              stream -> {
+                final JsonObject streamObject = stream.getAsJsonObject();
+                if (streamObject.has(ELEMENT_MEDIA)
+                    && streamObject.get(ELEMENT_MEDIA).isJsonArray()) {
+                  streamObject
+                      .get(ELEMENT_MEDIA)
+                      .getAsJsonArray()
+                      .forEach(
+                          media -> {
+                            final Optional<String> mimeType =
+                                JsonUtils.getElementValueAsString(media, ATTRIBUTE_MIMETYPE);
+                            if (mimeType.isPresent()
+                                && Arrays.stream(SUPPORTED_MIME_TYPES)
+                                    .anyMatch(type -> type.equals(mimeType.get()))) {
+                              final Optional<Integer> width =
+                                  JsonUtils.getAttributeAsInt(
+                                      media.getAsJsonObject(), ATTRIBUTE_WIDTH);
+                              final Optional<String> url =
+                                  JsonUtils.getElementValueAsString(media, ATTRIBUTE_URL);
+
+                              if (width.isPresent() && url.isPresent()) {
+                                final Qualities resolution =
+                                    Qualities.getResolutionFromWidth(width.get());
+                                urls.put(resolution, url.get());
+                              }
+                            }
+                          });
+                }
+              });
+    }
+    return urls;
+  }
+}

--- a/src/main/java/mServer/crawler/sender/tagesschau/tasks/TagesschauEntriesTask.java
+++ b/src/main/java/mServer/crawler/sender/tagesschau/tasks/TagesschauEntriesTask.java
@@ -1,0 +1,82 @@
+package mServer.crawler.sender.tagesschau.tasks;
+
+import de.mediathekview.mlib.Config;
+import de.mediathekview.mlib.tool.Log;
+import mServer.crawler.sender.MediathekReader;
+import mServer.crawler.sender.base.AbstractDocumentTask;
+import mServer.crawler.sender.base.AbstractRecursivConverterTask;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.tagesschau.EntryUrlDto;
+import mServer.crawler.sender.tagesschau.TagesschauConstants;
+
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.jspecify.annotations.NonNull;
+
+public class TagesschauEntriesTask extends AbstractDocumentTask<EntryUrlDto, CrawlerUrlDTO> {
+  private static final Logger LOG = LogManager.getLogger(TagesschauEntriesTask.class);
+
+  private static final Pattern PATTERN_VIDEO = Pattern.compile("/video-\\d+\\.html$");
+  private static final Pattern PATTERN_SUB_PAGE = Pattern.compile("/(tsvorzwanzigjahren(?:-ts)?-?\\d+)\\.html$");
+  private static final String[] BLACKLIST = new String[] {TagesschauConstants.ARCHIVE_START_URL};
+
+  public TagesschauEntriesTask(final MediathekReader crawler, final ConcurrentLinkedQueue<CrawlerUrlDTO> queue) {
+    super(crawler, queue);
+  }
+
+  @Override
+  protected void processDocument(CrawlerUrlDTO aUrlDTO, Document aDocument) {
+    if (Config.getStop()) {
+      return;
+    }
+
+    EntryUrlDto result = new EntryUrlDto();
+    LOG.debug("Processing Tagesschau overview page: {}", aUrlDTO.getUrl());
+
+    final Elements links = aDocument.select(".teaser-absatz__link");
+
+    for (final Element link : links) {
+      try {
+        final String href = link.attr("href");
+        if (href.isEmpty()) {
+          continue;
+        }
+        // normalize to absolute
+        final String fullUrl = href.startsWith("http") ? href : buildUrl(href);
+
+        if (Arrays.stream(BLACKLIST).noneMatch(fullUrl::equalsIgnoreCase)) {
+          final Matcher matcherSubPage = PATTERN_SUB_PAGE.matcher(fullUrl);
+          final Matcher matcherVideo = PATTERN_VIDEO.matcher(fullUrl);
+          if (matcherSubPage.find()) {
+            result.addSubPage(new CrawlerUrlDTO(fullUrl));
+          } else if (matcherVideo.find()) {
+            result.addVideo(new CrawlerUrlDTO(fullUrl));
+          }
+        }
+      } catch (final Exception e) {
+        LOG.error("Error while processing overview link", e);
+        Log.errorLog(346234837, e, aUrlDTO.getUrl());
+      }
+    }
+
+    taskResults.add(result);
+  }
+
+  private static @NonNull String buildUrl(String href) {
+    return "https://www.tagesschau.de" + (href.startsWith("/") ? "" : "/") + href;
+  }
+
+  @Override
+  protected AbstractRecursivConverterTask<EntryUrlDto, CrawlerUrlDTO> createNewOwnInstance(
+      ConcurrentLinkedQueue<CrawlerUrlDTO> aElementsToProcess) {
+    return new TagesschauEntriesTask(crawler, aElementsToProcess);
+  }
+}

--- a/src/main/java/mServer/crawler/sender/tagesschau/tasks/TagesschauVideoTask.java
+++ b/src/main/java/mServer/crawler/sender/tagesschau/tasks/TagesschauVideoTask.java
@@ -1,0 +1,63 @@
+package mServer.crawler.sender.tagesschau.tasks;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import de.mediathekview.mlib.Config;
+import de.mediathekview.mlib.daten.DatenFilm;
+import de.mediathekview.mlib.tool.Log;
+import mServer.crawler.sender.MediathekReader;
+import mServer.crawler.sender.base.AbstractDocumentTask;
+import mServer.crawler.sender.base.AbstractRecursivConverterTask;
+import mServer.crawler.sender.base.CrawlerUrlDTO;
+import mServer.crawler.sender.tagesschau.json.TagesschauVideoDeserializer;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jsoup.nodes.Document;
+
+public class TagesschauVideoTask extends AbstractDocumentTask<DatenFilm, CrawlerUrlDTO> {
+  private static final String DESCRIPTOR_MEDIA_PLAYER = "div[data-v-type=MediaPlayer]";
+  private static final Logger LOG = LogManager.getLogger(TagesschauVideoTask.class);
+
+  private static final Type FILM_TYPE_TOKEN = new TypeToken<List<DatenFilm>>() {}.getType();
+
+  public TagesschauVideoTask(MediathekReader crawler, ConcurrentLinkedQueue<CrawlerUrlDTO> queue) {
+    super(crawler, queue);
+  }
+
+  @Override
+  protected void processDocument(CrawlerUrlDTO aUrlDTO, Document aDocument) {
+    if (Config.getStop()) {
+      return;
+    }
+
+    final Gson gson =
+            new GsonBuilder()
+                    .registerTypeAdapter(FILM_TYPE_TOKEN, new TagesschauVideoDeserializer())
+                    .create();
+
+    aDocument
+        .select(DESCRIPTOR_MEDIA_PLAYER)
+        .forEach(
+            element -> {
+              try {
+                String json = element.attr("data-v");
+                final List<DatenFilm> films = gson.fromJson(json, FILM_TYPE_TOKEN);
+                taskResults.addAll(films);
+              } catch (Exception e) {
+                LOG.error(e);
+                Log.errorLog(346234838, e, aUrlDTO.getUrl());
+              }
+            });
+  }
+
+  @Override
+  protected AbstractRecursivConverterTask<DatenFilm, CrawlerUrlDTO> createNewOwnInstance(
+      ConcurrentLinkedQueue<CrawlerUrlDTO> aElementsToProcess) {
+    return new TagesschauVideoTask(crawler, aElementsToProcess);
+  }
+}


### PR DESCRIPTION
fixes #846 

beinhaltet einen neuen Crawler, in Konfiguration den Sender **TAGESSCHAU** ergänzen.   
die Sendungen werden unter tagesschau24 einsortiert, so dass alle Clients ihn unterstützen.