### PR TITLE
Modernize Maven dependencies and build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>de.mediathekview</groupId>
   <artifactId>MServer</artifactId>
-  <version>${release}</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -55,43 +55,39 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <release>4.0.1-SNAPSHOT</release>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <revision>4.0.1-SNAPSHOT</revision>
+    <maven.compiler.release>21</maven.compiler.release>
 
-    <assertj.version>3.27.4</assertj.version>
-    <byte-buddy.version>1.17.7</byte-buddy.version>
+    <assertj.version>3.27.7</assertj.version>
+    <byte-buddy.version>1.18.11</byte-buddy.version>
     <commons-compress.version>1.28.0</commons-compress.version>
-    <commons-net.version>3.12.0</commons-net.version>
-    <commons-lang.version>3.19.0</commons-lang.version>
-    <commons-text.version>1.14.0</commons-text.version>
+    <commons-lang.version>3.20.0</commons-lang.version>
+    <commons-text.version>1.15.0</commons-text.version>
     <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <guava.version>33.4.8-jre</guava.version>
-    <gson.version>2.13.1</gson.version>
-    <jsoup.version>1.21.1</jsoup.version>
-    <jersey.version>3.1.11</jersey.version>
-    <javax-jaxb.version>4.0.2</javax-jaxb.version>
-    <log4j2.version>2.25.1</log4j2.version>
-    <jetbrains-annotations.version>22.0.0</jetbrains-annotations.version>
-    <junit.version>5.13.4</junit.version>
+    <guava.version>33.6.0-jre</guava.version>
+    <gson.version>2.14.0</gson.version>
+    <jsoup.version>1.22.2</jsoup.version>
+    <jersey.version>3.1.12</jersey.version>
+    <javax-jaxb.version>4.0.5</javax-jaxb.version>
+    <log4j2.version>2.26.1</log4j2.version>
+    <jetbrains-annotations.version>26.1.0</jetbrains-annotations.version>
+    <junit.version>5.14.4</junit.version>
     <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
-    <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.0.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
-    <mockito.version>5.19.0</mockito.version>
-    <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-    <okhttp3.version>4.10.0</okhttp3.version>
-    <wiremock.version>2.35.2</wiremock.version>
-    <xz.version>1.10</xz.version>
+    <mockito.version>5.23.0</mockito.version>
+    <okhttp3.version>4.12.0</okhttp3.version>
+    <wiremock.version>3.13.2</wiremock.version>
+    <xz.version>1.12</xz.version>
     <yacl4j-core.version>0.9.2</yacl4j-core.version>
     <docker-maven-plugin.version>0.48.0</docker-maven-plugin.version>
     <sortpom-maven-plugin.version>3.2.0</sortpom-maven-plugin.version>
@@ -129,7 +125,7 @@
     <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.4</version>
+        <version>42.7.13</version>
     </dependency>
 
     <!-- HikariCP Connection Pool -->
@@ -250,21 +246,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -300,18 +284,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>oss.sonatype.org-snapshot</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-  </repositories>
   <build>
 
     <resources>
@@ -369,6 +341,7 @@
             </goals>
             <phase>prepare-package</phase>
             <configuration>
+              <includeScope>runtime</includeScope>
               <outputDirectory>${project.build.directory}/libs</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>false</overWriteSnapshots>
@@ -396,9 +369,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <additionalOptions>--source ${maven.compiler.target}</additionalOptions>
-        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -476,7 +446,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.11</version>
+        <version>0.8.15</version>
         <executions>
           <execution>
             <goals>
@@ -510,7 +480,7 @@
                 <image>
                   <name>mediathekview/mserver:${project.version}</name>
                   <build>
-                    <from>eclipse-temurin:${maven.compiler.target}</from>
+                    <from>eclipse-temurin:${maven.compiler.release}</from>
                     <maintainer>Nicklas Wiegandt &lt;nicklas@wiegandt.eu&gt;</maintainer>
                     <assembly>
                       <descriptor>docker-assembly.xml</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
+          <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
           <parallel>classes</parallel>
           <useUnlimitedThreads>true</useUnlimitedThreads>
           <perCoreThreadCount>true</perCoreThreadCount>

--- a/src/main/java/de/mediathekview/mserver/base/config/Log4JConfigurationFactory.java
+++ b/src/main/java/de/mediathekview/mserver/base/config/Log4JConfigurationFactory.java
@@ -157,7 +157,7 @@ public class Log4JConfigurationFactory extends ConfigurationFactory {
   @Override
   public Configuration getConfiguration(
       final LoggerContext loggerContext, final ConfigurationSource source) {
-    return getConfiguration(loggerContext, source.toString(), null);
+    return getConfiguration(loggerContext, source.toString(), (URI) null);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- update compatible runtime and test dependencies, including WireMock 3
- use Maven's CI-friendly revision and Java 21 release settings
- exclude test dependencies from packaged runtime libraries
- remove obsolete repository and unused Maven properties
- update dependency analysis tooling for Java 21

## Verification
- mvn -q clean package -DskipTests
- mvn -q test
- mvn -q dependency:analyze
- 445 tests passed with no failures or errors